### PR TITLE
feat: add image embedding, wardrobe CLIP encoding, and recommendation…

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -711,6 +711,31 @@ async def add_wardrobe_item(
         image_s3_key=image_s3_key,
     )
 
+    if image_s3_key:
+        import asyncio
+
+        async def _embed_wardrobe_image(item_id: str, s3_key: str) -> None:
+            try:
+                from app.services.embedding_service import encode_image
+
+                vec = encode_image(s3_key)
+                async with db_service.get_connection() as conn:
+                    async with conn.cursor() as cur:
+                        await cur.execute(
+                            "UPDATE wardrobe_items SET embedding = %s::vector WHERE item_id = %s",
+                            (vec.tolist(), item_id),
+                        )
+                        await conn.commit()
+                logger.info("Wardrobe image embedded: item_id=%s", item_id)
+            except Exception:
+                logger.error(
+                    "Failed to embed wardrobe image: item_id=%s",
+                    item_id,
+                    exc_info=True,
+                )
+
+        asyncio.create_task(_embed_wardrobe_image(item["item_id"], image_s3_key))
+
     image_url = get_image_presigned_url(image_s3_key) if image_s3_key else None
     return WardrobeItemResponse(
         item_id=item["item_id"],

--- a/app/services/embedding_service.py
+++ b/app/services/embedding_service.py
@@ -1,5 +1,6 @@
-"""CLIP ViT-B/32 text encoder with lazy import and module-level singleton cache."""
+"""CLIP ViT-B/32 text and image encoder with lazy import and module-level singleton cache."""
 
+import io
 import logging
 
 import numpy as np
@@ -9,27 +10,28 @@ logger = logging.getLogger(__name__)
 # Module-level singletons — None until first call
 _model = None
 _tokenizer = None
+_transform = None
 _CLIP_MODEL = "ViT-B-32"
 _CLIP_PRETRAINED = "laion400m_e32"
 
 
-def _load_model():
-    """Load CLIP once; cache for the lifetime of the warm Lambda instance."""
-    global _model, _tokenizer
+def _load_model_and_transform():
+    """Load CLIP once; cache model, tokenizer, and image transform for the lifetime of the process."""
+    global _model, _tokenizer, _transform
     if _model is not None:
-        return _model, _tokenizer
+        return _model, _tokenizer, _transform
 
     import open_clip  # lazy import — torch is not loaded until this line
     import torch  # noqa: F401 — imported here to keep cold-start cost deferred
 
     logger.info("Loading CLIP model %s (first call)", _CLIP_MODEL)
-    model, _, _ = open_clip.create_model_and_transforms(
+    model, _, preprocess_val = open_clip.create_model_and_transforms(
         _CLIP_MODEL, pretrained=_CLIP_PRETRAINED
     )
     model.eval()
     tokenizer = open_clip.get_tokenizer(_CLIP_MODEL)
-    _model, _tokenizer = model, tokenizer
-    return _model, _tokenizer
+    _model, _tokenizer, _transform = model, tokenizer, preprocess_val
+    return _model, _tokenizer, _transform
 
 
 def encode_text(text: str) -> np.ndarray:
@@ -48,7 +50,7 @@ def encode_text(text: str) -> np.ndarray:
     """
     import torch
 
-    model, tokenizer = _load_model()
+    model, tokenizer, _ = _load_model_and_transform()
 
     tokens = tokenizer([text])
     with torch.no_grad():
@@ -65,8 +67,66 @@ def encode_text(text: str) -> np.ndarray:
     return embedding
 
 
+def encode_image(url_or_s3_key: str) -> np.ndarray:
+    """
+    Encode an image using the CLIP ViT-B/32 image encoder.
+
+    Accepts a public URL (https://...) or an S3 key (wardrobe-images/...).
+    Returns a 512-dim float32 numpy array, L2-normalized unit vector — same
+    embedding space as encode_text.
+
+    IMPORTANT: Only runs on EC2. Do not import this function in Lambda code.
+    Image encoder weights are ~290MB; Lambda's unzipped limit is 250MB.
+
+    Args:
+        url_or_s3_key: Public URL or S3 key.
+
+    Returns:
+        np.ndarray of shape (512,), dtype float32, unit norm.
+    """
+    import torch
+    from PIL import Image
+
+    model, _, transform = _load_model_and_transform()
+
+    if url_or_s3_key.startswith("http"):
+        import requests
+
+        logger.debug("encode_image: fetching URL %s", url_or_s3_key[:120])
+        response = requests.get(url_or_s3_key, timeout=10)
+        response.raise_for_status()
+        image_bytes = response.content
+    else:
+        import boto3
+
+        logger.debug("encode_image: fetching S3 key %s", url_or_s3_key)
+        s3 = boto3.client("s3")
+        import os
+
+        bucket = os.environ.get("S3_BUCKET", "fitted-wardrobe-images")
+        obj = s3.get_object(Bucket=bucket, Key=url_or_s3_key)
+        image_bytes = obj["Body"].read()
+
+    image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    tensor = transform(image).unsqueeze(0)  # (1, 3, 224, 224)
+
+    with torch.no_grad():
+        features = model.encode_image(tensor)
+        features = features / features.norm(dim=-1, keepdim=True)  # L2 normalize
+
+    embedding: np.ndarray = features.cpu().numpy().astype(np.float32)[0]
+    logger.debug(
+        "encode_image: key=%r shape=%s norm=%.4f",
+        url_or_s3_key[:80],
+        embedding.shape,
+        float(np.linalg.norm(embedding)),
+    )
+    return embedding
+
+
 def reset_model_for_testing() -> None:
     """Reset cached singletons — call in test teardown to avoid state leakage."""
-    global _model, _tokenizer
+    global _model, _tokenizer, _transform
     _model = None
     _tokenizer = None
+    _transform = None

--- a/docs/two_tower_rec_system.md
+++ b/docs/two_tower_rec_system.md
@@ -12,9 +12,13 @@ User request
       ├── HIT  → return cached candidate list
       └── MISS → ANN search on catalog_items (Poshmark seed data)
                  → store results in cache
-  → Build user embedding (mean-pool wardrobe items, outfit tags, and style prefs)
+  → Build user embedding
+      ├── wardrobe items: mean-pool CLIP image embeddings (highest fidelity)
+      ├── style preference tags: mean-pool CLIP text embeddings (cold-start fallback)
+      └── generic fallback: "casual everyday clothing" (no wardrobe + no tags)
   → Two-Tower ranking: project user + item vectors, score by cosine similarity
-  → [Optional] Late interaction reranking: MaxSim over catalog patch embeddings
+  → Bradley-Terry preference reranking: blend with pairwise preference scores (no-op at cold start)
+  → [Optional] LLM explanation for top-K picks
   → Return top-K as ProductRecommendation objects
 ```
 
@@ -42,6 +46,7 @@ User request
 18. [Interaction Logging](#18-interaction-logging)
 19. [The Bradley-Terry Preference Reranker](#19-the-bradley-terry-preference-reranker)
 20. [Frontend: Wardrobe, Preferences, and Product Cards](#20-frontend-wardrobe-preferences-and-product-cards)
+21. [Image Embedding: Wardrobe Photo Encoding](#21-image-embedding-wardrobe-photo-encoding)
 
 ---
 
@@ -76,11 +81,20 @@ When the training pipeline (Week 8) runs, it overwrites those weights with learn
 
 > **Important — cold-start ranking quality:** With Xavier-initialized weights and no training data, two-tower ranking scores cluster near zero and are nearly indistinguishable across candidates. The ranking order before Week 8 is effectively random. This is expected and acceptable: the *retrieval* step (pgvector ANN search on CLIP embeddings) is semantically meaningful and returns plausible candidates; only the *reranking* step is uninformative until learned weights are loaded. Do not tune or A/B test ranking quality using the Xavier-initialized system — wait for the first trained checkpoint.
 
-### What we're _not_ building yet
+### What's complete
 
-- **Bradley-Terry preference reranker** — uses pairwise "I prefer A over B" signals collected from the UI. Deferred until there's real interaction data.
-- **CLIP image encoder** — the vision tower (~290MB) pushes us past Lambda's 250MB zip limit. We use the CLIP _text_ encoder only for now (same embedding space, much lighter).
-- **Training loop** — `scripts/train_two_towers.py` with `TripletMarginLoss`. Comes in Week 8.
+- **Two-tower ranking** — `UserTower` + `ItemTower` (Xavier init; S3 weight loading); full `recommend()` pipeline.
+- **Bradley-Terry preference reranker** — `get_preference_scores` + `rerank`; no-op at cold start; feeds from `preference_pairs` table.
+- **Interaction logging** — `POST /interactions` (click/save/dismiss) feeding future training data.
+- **Wardrobe CRUD + frontend** — upload, gallery, delete; HTMX throughout.
+- **Auth endpoints** — register, login, logout; JWT cookies.
+- **Product cards** — `product_card()` in frontend with save/dismiss fire-and-forget to `/log-interaction`.
+
+### What's next
+
+- **CLIP image encoder** — `encode_image(url_or_s3_key)` in `embedding_service.py`; runs on EC2 sidecar (Lambda 250MB limit). Triggered after wardrobe photo upload to populate `wardrobe_items.embedding`. Until this is live, the user tower always falls back to cold-start style tag encoding.
+- **Frontend recommendation flow** — wire `POST /recommend-products` into a "Shop" page or home-page section; render product card grid from API response.
+- **Training loop** — `scripts/train_two_towers.py` with `TripletMarginLoss`. Comes in Week 8 once enough interaction data accumulates.
 
 ---
 
@@ -106,7 +120,7 @@ class Item:
     price: float
     image_url: str
     product_url: str
-    source: str                         # 'poshmark_seed' | 'serpapi' | ...
+    source: str                         # 'poshmark_seed' | ...
     embedding: Optional[np.ndarray]     # 512-dim float32, L2-normalized; None until embedded
     attributes: dict = field(default_factory=dict)  # brand, size, condition, colors, ...
 ```
@@ -730,7 +744,7 @@ async def _load_items_from_s3(s3_key: str) -> Optional[list[Item]]:
 
 **File:** `app/services/dev_catalog_service.py`
 
-This service retrieves candidates from the `catalog_items` table — populated by the Poshmark ingestion script. It's the "fast path" candidate source used in dev and before SerpAPI live search is integrated.
+This service retrieves candidates from the `catalog_items` table — populated by the Poshmark ingestion script. It is the production candidate source; no live search integration is planned.
 
 ```python
 import logging
@@ -2769,6 +2783,171 @@ def nav_bar(session) -> Nav:
 
 ---
 
+## 21. Image Embedding: Wardrobe Photo Encoding
+
+### Why this matters
+
+`_build_user_embedding` currently builds the user vector from style preference tags (`"streetwear"`, `"navy"`) when no wardrobe embeddings exist. Text tags are useful priors, but they are stated preferences — the user describing how they _want_ to dress rather than what they actually own.
+
+Wardrobe photo embeddings are a much stronger signal. A photo of a navy blazer the user actually owns will embed in exactly the same CLIP space as the catalog items being ranked, producing a user vector that reflects demonstrated visual taste. Mean-pooling ten wardrobe item images gives the user tower a "centre of mass" in CLIP space that is far more informative than mean-pooling abstract style tags.
+
+Until `encode_image` is live and wardrobe items have embeddings, the user tower always falls back to cold-start behaviour — effectively ignoring uploaded photos.
+
+### The image encoder path
+
+CLIP ViT-B/32 has two encoders in the same shared embedding space:
+- **Text encoder** (~150MB unzipped): already live in `embedding_service.encode_text`
+- **Image encoder** (~290MB unzipped): exceeds Lambda's 250MB zip limit
+
+The image encoder therefore runs on the EC2 sidecar alongside the FastHTML frontend. Lambda endpoints that need image embeddings call it via internal HTTP, the same pattern described in `plan.md`.
+
+### `encode_image` implementation
+
+**File:** `app/services/embedding_service.py` (addition)
+
+```python
+def encode_image(url_or_s3_key: str) -> np.ndarray:
+    """
+    Encode an image using the CLIP ViT-B/32 image encoder.
+
+    Accepts either a public URL or an S3 key (fetched via boto3).
+    Preprocesses with CLIP's standard image transform (224×224 centre crop,
+    normalisation), runs through the image encoder, L2-normalises.
+
+    Returns a 512-dim float32 numpy array, unit norm — the same embedding
+    space as encode_text. A photo of a "navy blazer" and the text
+    "navy blazer" will be near neighbours after encoding.
+
+    Only runs on EC2 (not Lambda — image encoder weights ~290MB exceed
+    Lambda's 250MB unzipped package limit). Do not import this function
+    in any code that runs on Lambda.
+
+    Args:
+        url_or_s3_key: Public URL (https://...) or S3 key (wardrobe-images/...).
+
+    Returns:
+        np.ndarray of shape (512,), dtype float32, unit norm.
+    """
+    import io
+    import torch
+    from PIL import Image
+    import requests
+
+    model, _, transform = _load_model_with_transform()  # extended loader that returns transform
+
+    # Fetch image bytes
+    if url_or_s3_key.startswith("http"):
+        resp = requests.get(url_or_s3_key, timeout=10)
+        resp.raise_for_status()
+        image_bytes = resp.content
+    else:
+        import boto3
+        from app.core.config import config
+        s3 = boto3.client("s3")
+        obj = s3.get_object(Bucket=config.weather_bucket_name, Key=url_or_s3_key)
+        image_bytes = obj["Body"].read()
+
+    image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    image_tensor = transform(image).unsqueeze(0)   # (1, 3, 224, 224)
+
+    with torch.no_grad():
+        features = model.encode_image(image_tensor)
+        features = features / features.norm(dim=-1, keepdim=True)
+
+    embedding: np.ndarray = features.cpu().numpy().astype(np.float32)[0]
+    logger.debug(
+        "encode_image: key=%r shape=%s norm=%.4f",
+        url_or_s3_key[:80],
+        embedding.shape,
+        float(np.linalg.norm(embedding)),
+    )
+    return embedding
+```
+
+`_load_model_with_transform()` is the extended version of `_load_model()` that also returns the preprocessing transform:
+
+```python
+def _load_model_with_transform():
+    """Load CLIP model + image transform. Cached after first call."""
+    global _model, _tokenizer, _transform
+    if _model is not None:
+        return _model, _tokenizer, _transform
+
+    import open_clip, torch
+    model, _, transform = open_clip.create_model_and_transforms(
+        _CLIP_MODEL, pretrained=_CLIP_PRETRAINED
+    )
+    model.eval()
+    tokenizer = open_clip.get_tokenizer(_CLIP_MODEL)
+    _model, _tokenizer, _transform = model, tokenizer, transform
+    return _model, _tokenizer, _transform
+```
+
+### Post-upload embedding trigger
+
+After inserting a wardrobe item in `POST /wardrobe`, the backend schedules image encoding as a background task so the 201 response is not blocked:
+
+```python
+# In app/main.py — inside add_wardrobe_item, after wardrobe_service.create_wardrobe_item()
+
+if image_s3_key:
+    async def _embed_and_store(item_id: str, s3_key: str) -> None:
+        try:
+            from app.services.embedding_service import encode_image
+            vec = encode_image(s3_key)
+            async with db_service.get_connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        "UPDATE wardrobe_items SET embedding = %s::vector WHERE item_id = %s",
+                        (vec.tolist(), item_id),
+                    )
+                    await conn.commit()
+            logger.info("Wardrobe image embedded: item_id=%s", item_id)
+        except Exception:
+            logger.error("Failed to embed wardrobe image: item_id=%s", item_id, exc_info=True)
+
+    asyncio.create_task(_embed_and_store(item["item_id"], image_s3_key))
+```
+
+The task is fire-and-forget: if encoding fails (network error, model not warm), the item row keeps `embedding = NULL` and `_build_user_embedding` degrades to style tag encoding. No user-facing impact.
+
+### Backfill script
+
+**File:** `scripts/backfill_wardrobe_embeddings.py`
+
+Same pattern as `scripts/backfill_catalog_embeddings.py`:
+
+```bash
+# Open SSH tunnel to RDS, then:
+PYTHONPATH=. DATABASE_URL=postgresql://fitted:password@localhost:5432/fitted \
+    python scripts/backfill_wardrobe_embeddings.py
+```
+
+Idempotent: only fetches rows where `embedding IS NULL AND image_s3_key IS NOT NULL`. Processes in batches of 50, commits after each batch. Can be interrupted and resumed.
+
+### Testing
+
+Mock `_load_model_with_transform` and `requests.get` (or `boto3.client`) to avoid real network/model calls:
+
+```python
+def test_encode_image_returns_512_dim_unit_vector():
+    mock_model = MagicMock()
+    mock_features = torch.ones(1, 512)
+    mock_model.encode_image.return_value = mock_features
+    mock_transform = MagicMock(return_value=torch.zeros(3, 224, 224))
+
+    with patch("app.services.embedding_service._load_model_with_transform",
+               return_value=(mock_model, None, mock_transform)):
+        with patch("requests.get") as mock_get:
+            mock_get.return_value.content = _fake_jpeg_bytes()
+            result = encode_image("https://example.com/jacket.jpg")
+
+    assert result.shape == (512,)
+    assert abs(np.linalg.norm(result) - 1.0) < 1e-5
+```
+
+---
+
 ## Summary of Files
 
 | File | Purpose |
@@ -2795,6 +2974,8 @@ def nav_bar(session) -> Nav:
 | `app/services/preference_reranker.py` | Bradley-Terry MM reranker + `get_preference_scores` |
 | `tests/test_wardrobe_service.py` | Wardrobe CRUD tests (mock psycopg3) |
 | `tests/test_preference_reranker.py` | Bradley-Terry MM + rerank blending tests |
+| `app/services/embedding_service.py` *(pending)* | `encode_image(url_or_s3_key)` — CLIP image encoder for wardrobe photos |
+| `scripts/backfill_wardrobe_embeddings.py` *(pending)* | Backfill `wardrobe_items.embedding` from S3 images |
 
 ---
 

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -457,6 +457,41 @@ custom_css = Style(
     }
     .product-card-action-btn:hover { background-color: #f1f5f9; }
 
+    /* Product Grid & Shop Section */
+    .product-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: 0.75rem;
+        margin-top: 1rem;
+    }
+    .shop-section {
+        margin-top: 2rem;
+        padding-top: 1rem;
+        border-top: 2px solid #000;
+    }
+    .shop-section h3 {
+        font-size: 1rem;
+        font-weight: bold;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 0.75rem;
+    }
+    .shop-btn {
+        background-color: #95FB62;
+        border: 2px solid #000;
+        color: #000;
+        padding: 0.5rem 1.2rem;
+        cursor: pointer;
+        font-size: 0.875rem;
+        font-weight: bold;
+    }
+    .shop-btn:hover { background-color: #7de84a; }
+    .rec-meta {
+        font-size: 0.8rem;
+        color: #64748b;
+        margin-bottom: 0.75rem;
+    }
+
     /* Preferences Styles */
     .prefs-form {
         display: flex;
@@ -552,6 +587,7 @@ def nav_bar(session):
             [
                 A("Wardrobe", href="/wardrobe"),
                 A("Prefs", href="/preferences"),
+                A("Recs", href="/recommendations"),
                 A("Logout", href="/logout"),
             ]
         )
@@ -579,7 +615,13 @@ def outfit_item(label: str, value: str) -> Div:
     )
 
 
-def weather_results(location: str, weather: dict, forecast: dict, outfit: dict) -> Div:
+def weather_results(
+    location: str,
+    weather: dict,
+    forecast: dict,
+    outfit: dict,
+    show_shop_btn: bool = False,
+) -> Div:
     """Render weather and outfit results."""
     temp_f = weather.get("temp_f", "")
     min_temp_f = forecast.get("min_temp_f", "")
@@ -608,6 +650,27 @@ def weather_results(location: str, weather: dict, forecast: dict, outfit: dict) 
     if outfit_accessories and outfit_accessories != "None":
         outfit_items.append(outfit_item("Accessories", outfit_accessories))
 
+    shop_section = Div(id="rec-results")
+    if show_shop_btn:
+        shop_section = Div(
+            H3("Shop These Looks"),
+            Form(
+                Input(type="hidden", name="location", value=location),
+                Button(
+                    Span("Get Recommendations", cls="loading-text"),
+                    Span(cls="loading loading-spinner"),
+                    type="submit",
+                    cls="shop-btn",
+                ),
+                hx_post="/get-recommendations",
+                hx_target="#rec-results",
+                hx_swap="outerHTML",
+                hx_indicator="closest form",
+            ),
+            Div(id="rec-results"),
+            cls="shop-section",
+        )
+
     return Div(
         Div(
             Div(
@@ -634,6 +697,7 @@ def weather_results(location: str, weather: dict, forecast: dict, outfit: dict) 
             cls="weather-card retro-card",
         ),
         Div(*outfit_items, cls="outfit-section"),
+        shop_section,
         id="results",
     )
 
@@ -850,7 +914,13 @@ async def get_outfit(location: str, session):
                 location_info.get("country"),
             ]
             display_location = ", ".join(p for p in parts if p) or location.title()
-            return weather_results(display_location, weather, forecast, outfit)
+            return weather_results(
+                display_location,
+                weather,
+                forecast,
+                outfit,
+                show_shop_btn="access_token" in session,
+            )
     except Exception:
         logger.error(
             "Connection error fetching outfit for location=%s.", location, exc_info=True
@@ -1086,6 +1156,121 @@ async def log_interaction(item_id: str, interaction_type: str, session):
             interaction_type,
         )
     return ""
+
+
+# --- Recommendations Routes ---
+
+
+@app.get("/recommendations")
+async def recommendations_page(session):
+    """Full recommendations page — location form that fires /get-recommendations."""
+    if "access_token" not in session:
+        return RedirectResponse("/login")
+
+    return Title("Recommendations - Fitted"), Body(
+        nav_bar(session),
+        Div(
+            H2("Shop Recommendations"),
+            P(
+                "Enter a location to get personalized product picks based on the weather.",
+                style="color:#64748b;font-size:0.875rem;margin-bottom:1.5rem;",
+            ),
+            Form(
+                Div(
+                    Input(
+                        type="text",
+                        name="location",
+                        placeholder="Enter city (e.g., San Francisco)",
+                        required=True,
+                    ),
+                    cls="search-form-input-row",
+                ),
+                Div(
+                    Button(
+                        Span("Get Recommendations", cls="loading-text"),
+                        Span(cls="loading loading-spinner"),
+                        type="submit",
+                    ),
+                    cls="search-form-btn-row",
+                ),
+                hx_post="/get-recommendations",
+                hx_target="#rec-results",
+                hx_swap="outerHTML",
+                hx_indicator="closest form",
+                cls="search-form",
+            ),
+            Div(id="rec-results"),
+            cls="container",
+        ),
+        data_theme="light",
+    )
+
+
+@app.post("/get-recommendations")
+async def get_recommendations(location: str, session):
+    """HTMX fragment: call POST /recommend-products, return a product card grid."""
+    if "access_token" not in session:
+        return P("Please log in to get recommendations.", cls="error-message")
+
+    if not location or not location.strip():
+        return P("Please enter a location.", cls="error-message")
+
+    location = location.strip()
+    token = session["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    logger.info("Recommendations request from frontend for location=%s", location)
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{API_BASE_URL}/recommend-products",
+                json={"location": location, "include_explanation": False},
+                headers=headers,
+                timeout=45.0,
+            )
+            if resp.status_code != 200:
+                err = resp.json().get("detail", "Unknown error")
+                logger.error(
+                    "Backend returned error for recommendations: location=%s status=%d detail=%s",
+                    location,
+                    resp.status_code,
+                    err,
+                )
+                return P(f"Error: {err}", cls="error-message", id="rec-results")
+
+            data = resp.json()
+            recommendations = data.get("recommendations", [])
+            weather = data.get("weather", {})
+            temp_c = weather.get("temp_c", 0.0)
+            condition = weather.get("condition", "")
+
+    except Exception:
+        logger.error(
+            "Connection error fetching recommendations for location=%s.",
+            location,
+            exc_info=True,
+        )
+        return P(
+            "Connection error: could not reach the server.",
+            cls="error-message",
+            id="rec-results",
+        )
+
+    if not recommendations:
+        return P(
+            "No recommendations found for this location.",
+            cls="rec-meta",
+            id="rec-results",
+        )
+
+    return Div(
+        P(
+            f"Top picks for {location} ({condition}, {temp_c:.0f}\u00b0C)",
+            cls="rec-meta",
+        ),
+        Div(*[product_card(item) for item in recommendations], cls="product-grid"),
+        id="rec-results",
+    )
 
 
 # --- Preferences Routes ---

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,6 @@
 # Fitted — Engineering Plan
 
-**Status:** Week 6 core complete — preference reranker + interaction endpoints pending
+**Status:** Week 7 complete — image embedding + frontend recommendation flow pending
 **Stack:** FastHTML on EC2 · FastAPI on Lambda · PostgreSQL + pgvector on RDS · S3 · CLIP ViT-B/32
 
 ---
@@ -28,10 +28,8 @@ User → FastHTML (EC2)
           → LLM (OpenRouter): generate search query from preferences + weather
           → VectorCache.lookup(query_embedding): pgvector semantic search on query_cache
                ├── HIT  → return cached candidates
-               └── MISS → SerpAPI → persist thumbnails to S3
-                                  → CLIP embed via EC2 embedding service
-                                  → upsert catalog_items
-                                  → cache query embedding
+               └── MISS → ANN search on catalog_items (Poshmark dev catalog)
+                        → cache query embedding
           → TwoTowers.rank(user_embedding, candidates)
           → PreferenceReranker.rerank(candidates, preference_pairs)
           → LLM: generate natural language explanation
@@ -66,9 +64,6 @@ graph TD
     API --> EMBS
     API --> PG
     API --> LLM[OpenRouter]
-    API --> SERP[SerpAPI]
-    SERP --> IMAGES
-    SERP --> BRONZE
     BRONZE --> DBT[dbt] --> PG
     MODELS --> API
 ```
@@ -191,7 +186,7 @@ class Item:
 query embedding (CLIP text)
     → vector_cache.lookup(threshold=0.85)         # semantic cache on query_cache table
         ├── HIT  → cached candidates
-        └── MISS → SerpAPI → S3 thumbnail persist → CLIP encode → catalog_items upsert → cache
+        └── MISS → ANN search on catalog_items (Poshmark catalog) → cache
 
 candidates
     → UserTower(wardrobe_embeddings, preferences) → 512-dim user vector
@@ -221,15 +216,15 @@ WeatherAPI integration, S3 bronze/silver/gold, Athena analytics endpoints.
 ### ✅ Week 3 — API Hardening + Frontend
 Pydantic validation, forecast support, FastHTML frontend, S3-backed caching.
 
-### 🔄 Week 4 — EC2 + RDS + Auth + Wardrobe
+### ✅ Week 4 — EC2 + RDS + Auth + Wardrobe
 - [x] SSH key, SSM secrets
 - [x] CloudFormation: VPC (IPv6), EC2 t4g.micro (Elastic IP), RDS db.t4g.micro (PostgreSQL 16 + pgvector), security groups, IAM
 - [x] DB schema: `users`, `wardrobe_items` (VECTOR(512)), HNSW index, `updated_at` trigger, psycopg async pool
 - [x] EC2 deploy: Caddy (COPR), systemd services, Caddyfile, `config.py` SSM support, FastHTML prod mode
-- [ ] Auth + Wardrobe API: JWT (dev bypass when `DEV_MODE=true`), S3 presign/upload/delete, `/auth/*` and `/wardrobe/*`
-- [ ] Tests: psycopg3 cursor mocks, moto S3, auth + wardrobe coverage
-- [ ] Frontend: login/register, nav, upload form, gallery, HTMX delete
-- [ ] User preferences: JSONB style prefs (colors, styles, occasions), LLM prompt integration
+- [x] Auth + Wardrobe API: JWT (dev bypass when `DEV_MODE=true`), S3 presign/upload/delete, `/auth/*` and `/wardrobe/*`
+- [x] Tests: psycopg3 cursor mocks, moto S3, auth + wardrobe coverage
+- [x] Frontend: login/register, nav, upload form, gallery, HTMX delete
+- [x] User preferences: JSONB style prefs (colors, styles, occasions), LLM prompt integration
 
 **Cost:** $0 during free tier · ~$3.60/mo Elastic IP · ~$18/mo post-free-tier
 
@@ -237,8 +232,8 @@ Pydantic validation, forecast support, FastHTML frontend, S3-backed caching.
 
 **5A — CLIP Embedding Service**
 - [x] `app/services/embedding_service.py` — CLIP ViT-B/32 text encoder; lazy-import singleton; `encode_text(text) -> np.ndarray` (512-dim L2-normalized); `reset_model_for_testing()`
-- [ ] `scripts/backfill_wardrobe_embeddings.py` — backfill `wardrobe_items.embedding` for existing photos (deferred; no wardrobe photos exist yet)
-- [ ] `encode_image(url_or_s3_key)` — image encoder path (deferred; Lambda 250MB limit; will run on EC2 sidecar)
+- [ ] `encode_image(url_or_s3_key)` — CLIP ViT-B/32 image encoder path; runs on EC2 sidecar (Lambda 250MB limit); triggered after wardrobe upload to populate `wardrobe_items.embedding`
+- [ ] `scripts/backfill_wardrobe_embeddings.py` — backfill `wardrobe_items.embedding` for existing photos; fetches from S3, encodes with CLIP image encoder; run via SSH tunnel
 
 **5A.5 — Domain Protocol**
 - [x] `app/services/domain.py` — `@runtime_checkable` `Domain` Protocol with `encode_query`, `encode_item`, `parse_item`, `preference_context`
@@ -255,9 +250,9 @@ Pydantic validation, forecast support, FastHTML frontend, S3-backed caching.
 - [x] `app/services/vector_cache.py` — `lookup(query_embedding, threshold=0.15)` + `store(...)`; cosine distance ANN on `query_cache`; S3-backed candidate serialization; 24h TTL; `ON CONFLICT` upsert
 - [x] `app/services/candidate_source.py` — factory routing `DEV_MODE=true` → dev catalog; prod path stub (returns `[]` with warning)
 - [x] `llm_service.generate_search_query(preferences, weather) -> str` — 5–10 word NL query; rule-based fallback
-- [ ] `app/services/serpapi_service.py` — live product search for prod path (deferred to Week 5C remainder)
+- Production candidate source: dev catalog (Poshmark) — no live search integration planned; `candidate_source.py` prod path remains unused
 
-### 🔄 Week 6 — Two-Towers + Preference Re-ranker
+### ✅ Week 6 — Two-Towers + Preference Re-ranker
 
 **Two-Tower Model (complete)**
 - [x] `app/models/product.py` — `ProductRecommendation` Pydantic model with `similarity_score`, optional `llm_explanation`
@@ -271,16 +266,31 @@ Pydantic validation, forecast support, FastHTML frontend, S3-backed caching.
 - [x] `tests/test_recommendation_service.py` — 31 tests across UserTower, ItemTower, `rank`, `_build_user_embedding`, `recommend`, singleton lifecycle
 - [x] `llm_service.generate_explanation(top_items, weather_context, style_preferences) -> str` — 2–3 sentence explanation; gated behind `include_explanation=True`
 
-**Pending**
-- [ ] `app/services/preference_reranker.py` — Bradley-Terry on `preference_pairs`; `rerank(query, candidates)`, `update(pairs)`
-- [ ] `POST /interactions` — log click/save/dismiss events to `user_interactions`
-- [ ] `POST /preferences/pairs` — record pairwise preference signals
-- [ ] `tests/test_preference_reranker.py`
-- [ ] `scripts/pretrain_item_tower.py` — pre-train ItemTower on dev catalog embeddings (optional; Xavier init acceptable until Week 8)
+**Complete**
+- [x] `app/services/preference_reranker.py` — Bradley-Terry MM on `preference_pairs`; `get_preference_scores`, `rerank` with alpha blending
+- [x] `POST /interactions` — log click/save/dismiss events to `user_interactions`
+- [x] `POST /preferences/pairs` — record pairwise preference signals
+- [x] `tests/test_preference_reranker.py`
 
-### Week 7 — LLM Explanation + Product Cards
+### ✅ Week 7 — LLM Explanation + Product Cards
 - [x] `llm_service.generate_explanation` — narrates top-3 picks (implemented in Week 6 alongside `recommend`)
-- [ ] `product_card(product) -> Div` in `frontend/app.py`; HTMX click → `POST /interactions`
+- [x] `product_card(product) -> Div` in `frontend/app.py`; save/dismiss HTMX → `/log-interaction` → `POST /interactions`
+- [x] Frontend auth: login/register pages, session management, JWT cookie
+- [x] Frontend wardrobe: upload form, gallery grid, HTMX delete
+
+**Pending**
+- [ ] Wire `POST /recommend-products` into frontend — "Get Recommendations" flow; render `product_card` grid from API response
+
+### Image Embedding — Wardrobe Photo Encoding
+
+Currently `wardrobe_items.embedding` is always NULL — the user tower falls back to cold-start style tag encoding. Image embedding closes that gap: wardrobe photos are encoded with CLIP's image encoder and stored, so the user vector reflects actual visual taste rather than stated preferences.
+
+- [ ] `encode_image(url_or_s3_key: str) -> np.ndarray` in `embedding_service.py` — CLIP ViT-B/32 image encoder; downloads image from URL or S3 key; preprocesses with CLIP's `transform` pipeline; returns 512-dim L2-normalized float32 ndarray; runs only on EC2 (not Lambda)
+- [ ] Post-upload embedding trigger in `POST /wardrobe` — after inserting the wardrobe row, call `encode_image(image_s3_key)` and `UPDATE wardrobe_items SET embedding = %s WHERE item_id = %s`; fire-and-forget via `asyncio.create_task` so it doesn't block the 201 response
+- [ ] `scripts/backfill_wardrobe_embeddings.py` — idempotent batch script; fetches all `wardrobe_items` where `embedding IS NULL AND image_s3_key IS NOT NULL`; encodes via CLIP image encoder; writes back in batches of 50; run via SSH tunnel
+- [ ] Tests: mock CLIP image transform + model in `test_embedding_service.py`; test `encode_image` returns unit vector with correct shape
+
+> **Deployment note:** `encode_image` is imported only inside the `POST /wardrobe` endpoint handler (lazy import), keeping the Lambda package size below 250MB. The actual CLIP image encoder weights (~290MB) are only present on the EC2 instance.
 
 ### Week 8 — Training Pipeline
 - [ ] `scripts/train_two_towers.py` — interactions → triplets → `TripletMarginLoss(margin=0.2)` → `s3://fitted/models/two-towers/latest.pt`
@@ -314,7 +324,7 @@ Pydantic validation, forecast support, FastHTML frontend, S3-backed caching.
 |---|---|---|
 | Embedding model | CLIP ViT-B/32 (512-dim) | Unified image+text space; no fusion layer needed |
 | CLIP deployment | EC2 sidecar, not Lambda | Lambda 250MB limit + cold start latency |
-| Dev catalog | Poshmark seed (ingestion scripts) | Real secondhand listings; no SerpAPI spend during dev |
+| Dev catalog | Poshmark seed (ingestion scripts) | Real secondhand listings; SerpAPI integration dropped — dev catalog is the permanent candidate source |
 | Vector cache | pgvector cosine distance threshold 0.15 (≈ similarity 0.85) | Reuse candidates for semantically similar queries; cut CLIP encode cost |
 | Two-tower init | Xavier uniform (cold start) | Retrieval is semantically meaningful; ranking quality improves after Week 8 training |
 | ML platform | S3 + dbt + Airflow on EC2 | No need for Databricks at this scale |

--- a/scripts/backfill_wardrobe_embeddings.py
+++ b/scripts/backfill_wardrobe_embeddings.py
@@ -1,0 +1,143 @@
+"""
+Backfill CLIP image embeddings for wardrobe_items where embedding IS NULL.
+
+Runs on EC2 (CLIP image encoder is ~290MB — too large for Lambda).
+
+    # Open SSH tunnel first, then:
+    PYTHONPATH=. DATABASE_URL=postgresql://...@localhost:5432/fitted \\
+        python scripts/backfill_wardrobe_embeddings.py
+
+Options:
+    --batch-size N   Rows per DB commit (default: 100)
+    --dry-run        Log without writing
+    --limit N        Stop after N items (0 = unlimited)
+"""
+
+import argparse
+import logging
+import pathlib
+import sys
+
+import psycopg
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from app.core.config import config
+from app.services.embedding_service import encode_image
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("backfill_wardrobe_embeddings")
+
+logger.info("Backfill CLIP image embeddings for wardrobe_items where embedding IS NULL")
+
+
+def fetch_unembedded_batch(conn: psycopg.Connection, batch_size: int) -> list[dict]:
+    """Return up to batch_size rows where embedding IS NULL and image_s3_key is set."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT item_id, image_s3_key
+            FROM wardrobe_items
+            WHERE embedding IS NULL AND image_s3_key IS NOT NULL
+            LIMIT %s
+            """,
+            (batch_size,),
+        )
+        rows = cur.fetchall()
+
+    return [{"item_id": row[0], "image_s3_key": row[1]} for row in rows]
+
+
+def embed_batch(items: list[dict]) -> list[tuple[str, list[float]]]:
+    """
+    Encode each item's wardrobe image via CLIP image encoder.
+
+    Returns (item_id, embedding_as_list) pairs.
+    """
+    results = []
+    for item in items:
+        vec = encode_image(item["image_s3_key"])
+        results.append((item["item_id"], vec.tolist()))
+    return results
+
+
+def write_embeddings(
+    conn: psycopg.Connection,
+    embeddings: list[tuple[str, list[float]]],
+) -> int:
+    """
+    UPDATE wardrobe_items SET embedding = %s::vector WHERE item_id = %s.
+
+    Returns the number of rows updated.
+    """
+    with conn.cursor() as cur:
+        for item_id, vec in embeddings:
+            cur.execute(
+                """
+                UPDATE wardrobe_items
+                SET embedding = %s::vector
+                WHERE item_id = %s
+                """,
+                (vec, item_id),
+            )
+    conn.commit()
+    return len(embeddings)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Main loop: fetch batch → embed → write → repeat."""
+    conn = psycopg.connect(config.database_url)
+    total_done = 0
+
+    try:
+        while True:
+            batch = fetch_unembedded_batch(conn, args.batch_size)
+            if not batch:
+                logger.info("No more unembedded items. Done.")
+                break
+
+            if args.dry_run:
+                logger.info("[DRY RUN] Would embed %d items", len(batch))
+                break
+
+            embeddings = embed_batch(batch)
+            written = write_embeddings(conn, embeddings)
+            total_done += written
+            logger.info("Embedded %d items (total so far: %d)", written, total_done)
+
+            if args.limit and total_done >= args.limit:
+                logger.info("Reached --limit=%d — stopping", args.limit)
+                break
+
+    finally:
+        conn.close()
+
+    logger.info("Backfill complete. Total embedded: %d", total_done)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill CLIP image embeddings for wardrobe_items"
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Rows per DB commit (default: 100)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log without writing embeddings",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Stop after N items; 0 = no limit (default: 0)",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    run(_parse_args())

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -4,6 +4,7 @@ CLIP model loading is mocked at the open_clip level — no weights are downloade
 or loaded in CI.
 """
 
+import io
 import numpy as np
 import pytest
 import torch
@@ -21,9 +22,10 @@ def reset_clip_singleton():
 
 
 def _make_mock_model(dim: int = 512) -> MagicMock:
-    """Return a mock CLIP model whose encode_text returns a (1, dim) tensor."""
+    """Return a mock CLIP model whose encode_text and encode_image return a (1, dim) tensor."""
     mock_model = MagicMock()
     mock_model.encode_text.return_value = torch.ones(1, dim)
+    mock_model.encode_image.return_value = torch.ones(1, dim)
     return mock_model
 
 
@@ -39,8 +41,8 @@ def _make_mock_tokenizer() -> MagicMock:
 def test_encode_text_returns_512_dim_unit_vector():
     """encode_text should return a (512,) float32 array with unit norm."""
     with patch(
-        "app.services.embedding_service._load_model",
-        return_value=(_make_mock_model(), _make_mock_tokenizer()),
+        "app.services.embedding_service._load_model_and_transform",
+        return_value=(_make_mock_model(), _make_mock_tokenizer(), MagicMock()),
     ):
         from app.services.embedding_service import encode_text
 
@@ -57,8 +59,8 @@ def test_encode_text_calls_model_encode_text():
     mock_tokenizer = MagicMock(return_value="mock_tokens")
 
     with patch(
-        "app.services.embedding_service._load_model",
-        return_value=(mock_model, mock_tokenizer),
+        "app.services.embedding_service._load_model_and_transform",
+        return_value=(mock_model, mock_tokenizer, MagicMock()),
     ):
         from app.services.embedding_service import encode_text
 
@@ -74,8 +76,8 @@ def test_encode_text_l2_normalizes_output():
     mock_model.encode_text.return_value = torch.full((1, 512), 5.0)
 
     with patch(
-        "app.services.embedding_service._load_model",
-        return_value=(mock_model, _make_mock_tokenizer()),
+        "app.services.embedding_service._load_model_and_transform",
+        return_value=(mock_model, _make_mock_tokenizer(), MagicMock()),
     ):
         from app.services.embedding_service import encode_text
 
@@ -90,8 +92,8 @@ def test_encode_text_returns_float32():
     mock_model.encode_text.return_value = torch.ones(1, 512, dtype=torch.float64)
 
     with patch(
-        "app.services.embedding_service._load_model",
-        return_value=(mock_model, _make_mock_tokenizer()),
+        "app.services.embedding_service._load_model_and_transform",
+        return_value=(mock_model, _make_mock_tokenizer(), MagicMock()),
     ):
         from app.services.embedding_service import encode_text
 
@@ -106,16 +108,16 @@ def test_encode_text_returns_float32():
 
 
 def test_load_model_called_only_once_across_multiple_encodes():
-    """_load_model should be called exactly once even if encode_text is called twice."""
+    """_load_model_and_transform should be called exactly once even if encode_text is called twice."""
     call_count = {"n": 0}
-    mock_pair = (_make_mock_model(), _make_mock_tokenizer())
+    mock_triple = (_make_mock_model(), _make_mock_tokenizer(), MagicMock())
 
     def _counting_load():
         call_count["n"] += 1
-        return mock_pair
+        return mock_triple
 
     with patch(
-        "app.services.embedding_service._load_model",
+        "app.services.embedding_service._load_model_and_transform",
         side_effect=_counting_load,
     ):
         from app.services.embedding_service import encode_text
@@ -127,17 +129,19 @@ def test_load_model_called_only_once_across_multiple_encodes():
 
 
 def test_reset_model_for_testing_clears_singletons():
-    """reset_model_for_testing should set both singletons back to None."""
+    """reset_model_for_testing should set all three singletons back to None."""
     import app.services.embedding_service as svc
 
     # Manually set the singletons to non-None values
     svc._model = MagicMock()
     svc._tokenizer = MagicMock()
+    svc._transform = MagicMock()
 
     reset_model_for_testing()
 
     assert svc._model is None
     assert svc._tokenizer is None
+    assert svc._transform is None
 
 
 def test_singleton_reused_after_first_load():
@@ -145,13 +149,108 @@ def test_singleton_reused_after_first_load():
     import app.services.embedding_service as svc
 
     with patch(
-        "app.services.embedding_service._load_model",
-        return_value=(_make_mock_model(), _make_mock_tokenizer()),
+        "app.services.embedding_service._load_model_and_transform",
+        return_value=(_make_mock_model(), _make_mock_tokenizer(), MagicMock()),
     ):
         from app.services.embedding_service import encode_text
 
         encode_text("prime the cache")
 
-    # The patched _load_model doesn't actually set the singletons, but we can
-    # verify the module's public API doesn't raise when called repeatedly.
+    # The patched _load_model_and_transform doesn't actually set the singletons,
+    # but we can verify the module's public API doesn't raise when called repeatedly.
     # (Real singleton caching is tested implicitly via integration tests.)
+
+
+# ---------------------------------------------------------------------------
+# encode_image — shape, dtype, norm, S3 vs URL dispatch
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_jpeg_bytes() -> bytes:
+    """Create a minimal 1x1 white JPEG in memory."""
+    from PIL import Image
+
+    buf = io.BytesIO()
+    img = Image.new("RGB", (1, 1), color=(255, 255, 255))
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _make_mock_transform() -> MagicMock:
+    """Return a mock image transform that produces a (3, 224, 224) tensor."""
+    mock_transform = MagicMock()
+    mock_transform.return_value = torch.zeros(3, 224, 224)
+    return mock_transform
+
+
+def test_encode_image_url_returns_512_dim_unit_vector():
+    """encode_image from a URL should return a (512,) float32 unit vector."""
+    import requests as requests_module
+
+    mock_model = _make_mock_model()
+    mock_transform = _make_mock_transform()
+    fake_jpeg = _make_fake_jpeg_bytes()
+
+    mock_response = MagicMock()
+    mock_response.content = fake_jpeg
+    mock_response.raise_for_status = MagicMock()
+
+    with patch(
+        "app.services.embedding_service._load_model_and_transform",
+        return_value=(mock_model, _make_mock_tokenizer(), mock_transform),
+    ), patch("requests.get", return_value=mock_response):
+        from app.services.embedding_service import encode_image
+
+        result = encode_image("https://example.com/shirt.jpg")
+
+    assert result.shape == (512,)
+    assert result.dtype == np.float32
+    assert abs(np.linalg.norm(result) - 1.0) < 1e-5, "Result must be a unit vector"
+
+
+def test_encode_image_s3_key_fetches_from_s3():
+    """encode_image with an S3 key should call boto3 get_object with the right key."""
+    mock_model = _make_mock_model()
+    mock_transform = _make_mock_transform()
+    fake_jpeg = _make_fake_jpeg_bytes()
+
+    mock_s3_client = MagicMock()
+    mock_body = MagicMock()
+    mock_body.read.return_value = fake_jpeg
+    mock_s3_client.get_object.return_value = {"Body": mock_body}
+
+    with patch(
+        "app.services.embedding_service._load_model_and_transform",
+        return_value=(mock_model, _make_mock_tokenizer(), mock_transform),
+    ), patch("boto3.client", return_value=mock_s3_client):
+        from app.services.embedding_service import encode_image
+
+        result = encode_image("wardrobe-images/user-123/item-456.jpg")
+
+    mock_s3_client.get_object.assert_called_once()
+    call_kwargs = mock_s3_client.get_object.call_args
+    assert call_kwargs.kwargs.get("Key") == "wardrobe-images/user-123/item-456.jpg"
+    assert result.shape == (512,)
+
+
+def test_encode_image_url_is_l2_normalized():
+    """encode_image output must have unit norm (cosine similarity = dot product)."""
+    mock_model = MagicMock()
+    # Return a non-unit raw tensor to confirm normalization is applied
+    mock_model.encode_image.return_value = torch.full((1, 512), 3.0)
+    mock_transform = _make_mock_transform()
+    fake_jpeg = _make_fake_jpeg_bytes()
+
+    mock_response = MagicMock()
+    mock_response.content = fake_jpeg
+    mock_response.raise_for_status = MagicMock()
+
+    with patch(
+        "app.services.embedding_service._load_model_and_transform",
+        return_value=(mock_model, _make_mock_tokenizer(), mock_transform),
+    ), patch("requests.get", return_value=mock_response):
+        from app.services.embedding_service import encode_image
+
+        result = encode_image("https://example.com/pants.jpg")
+
+    assert abs(np.linalg.norm(result) - 1.0) < 1e-5

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -9,6 +9,7 @@ Strategy:
 - For routes that call the backend API, mock httpx.AsyncClient so no real
   HTTP requests are made.
 """
+
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -126,7 +127,9 @@ class TestLoginPage:
         response = client.get("/login")
         assert b"password" in response.content.lower()
 
-    def test_login_page_redirects_to_home_when_already_authenticated(self, authed_client):
+    def test_login_page_redirects_to_home_when_already_authenticated(
+        self, authed_client
+    ):
         response = authed_client.get("/login")
         # Already logged-in users are redirected away from /login
         # FastHTML's RedirectResponse uses 303 by default; Starlette may use 307
@@ -218,7 +221,11 @@ class TestRegisterPost:
             )
             response = client.post(
                 "/register",
-                data={"full_name": "New User", "email": "new@example.com", "password": "pw"},
+                data={
+                    "full_name": "New User",
+                    "email": "new@example.com",
+                    "password": "pw",
+                },
             )
         assert response.status_code in (302, 303)
         assert "/login" in response.headers.get("location", "")
@@ -232,7 +239,11 @@ class TestRegisterPost:
             )
             response = client.post(
                 "/register",
-                data={"full_name": "Existing", "email": "existing@example.com", "password": "pw"},
+                data={
+                    "full_name": "Existing",
+                    "email": "existing@example.com",
+                    "password": "pw",
+                },
             )
         assert response.status_code == 200
         assert b"already exists" in response.content
@@ -317,7 +328,10 @@ class TestGetOutfit:
             mock_instance.post.side_effect = Exception("Connection refused")
             response = client.post("/get-outfit", data={"location": "London"})
         assert response.status_code == 200
-        assert b"Connection error" in response.content or b"could not reach" in response.content
+        assert (
+            b"Connection error" in response.content
+            or b"could not reach" in response.content
+        )
 
     def test_authenticated_request_sends_bearer_token(self, authed_client):
         with patch("httpx.AsyncClient") as mock_http:
@@ -346,3 +360,209 @@ class TestGetOutfit:
         call_kwargs = mock_instance.post.call_args
         headers = call_kwargs[1].get("headers", {})
         assert "Authorization" not in headers
+
+    def test_authenticated_outfit_response_includes_shop_button(self, authed_client):
+        """Logged-in users see a 'Get Recommendations' button after outfit results."""
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.post.return_value = _make_http_response(
+                200, MOCK_BACKEND_OUTFIT_RESPONSE
+            )
+            response = authed_client.post("/get-outfit", data={"location": "London"})
+        assert response.status_code == 200
+        assert b"get-recommendations" in response.content
+
+    def test_unauthenticated_outfit_response_excludes_shop_button(self, client):
+        """Anonymous users do not see the 'Get Recommendations' button."""
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.post.return_value = _make_http_response(
+                200, MOCK_BACKEND_OUTFIT_RESPONSE
+            )
+            response = client.post("/get-outfit", data={"location": "London"})
+        assert response.status_code == 200
+        assert b"get-recommendations" not in response.content
+
+
+# ---------------------------------------------------------------------------
+# GET /recommendations
+# ---------------------------------------------------------------------------
+
+MOCK_BACKEND_RECOMMENDATIONS_RESPONSE = {
+    "user_id": "abc-123",
+    "location": "London",
+    "weather": {"temp_c": 12.0, "condition": "Partly cloudy", "location": "London"},
+    "count": 2,
+    "recommendations": [
+        {
+            "item_id": "item-1",
+            "title": "Navy Slim-Fit Chinos",
+            "price": 45.0,
+            "product_url": "https://poshmark.com/listing/1",
+            "image_url": "https://example.com/img1.jpg",
+            "similarity_score": 0.87,
+            "attributes": {"brand": "Gap", "category": "bottoms"},
+            "llm_explanation": None,
+        },
+        {
+            "item_id": "item-2",
+            "title": "White Oxford Shirt",
+            "price": 30.0,
+            "product_url": "https://poshmark.com/listing/2",
+            "image_url": None,
+            "similarity_score": 0.82,
+            "attributes": {"brand": "J.Crew", "category": "tops"},
+            "llm_explanation": None,
+        },
+    ],
+}
+
+
+class TestRecommendationsPage:
+    def test_recommendations_page_redirects_when_unauthenticated(self, client):
+        response = client.get("/recommendations")
+        assert response.status_code in (302, 303, 307)
+        assert "/login" in response.headers.get("location", "")
+
+    def test_recommendations_page_returns_200_when_authenticated(self, authed_client):
+        response = authed_client.get("/recommendations")
+        assert response.status_code == 200
+
+    def test_recommendations_page_contains_form(self, authed_client):
+        response = authed_client.get("/recommendations")
+        assert b"get-recommendations" in response.content
+
+    def test_recommendations_page_shows_nav_link(self, authed_client):
+        response = authed_client.get("/recommendations")
+        assert (
+            b"Recs" in response.content
+            or b"recommendations" in response.content.lower()
+        )
+
+
+# ---------------------------------------------------------------------------
+# POST /get-recommendations
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecommendations:
+    def test_unauthenticated_returns_login_prompt(self, client):
+        response = client.post("/get-recommendations", data={"location": "London"})
+        assert response.status_code == 200
+        assert b"log in" in response.content.lower()
+
+    def test_successful_response_returns_product_cards(self, authed_client):
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.post.return_value = _make_http_response(
+                200, MOCK_BACKEND_RECOMMENDATIONS_RESPONSE
+            )
+            response = authed_client.post(
+                "/get-recommendations", data={"location": "London"}
+            )
+        assert response.status_code == 200
+        assert b"Navy Slim-Fit Chinos" in response.content
+        assert b"White Oxford Shirt" in response.content
+
+    def test_successful_response_includes_weather_meta(self, authed_client):
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.post.return_value = _make_http_response(
+                200, MOCK_BACKEND_RECOMMENDATIONS_RESPONSE
+            )
+            response = authed_client.post(
+                "/get-recommendations", data={"location": "London"}
+            )
+        assert response.status_code == 200
+        assert b"London" in response.content
+        assert b"Partly cloudy" in response.content
+
+    def test_backend_error_returns_error_message(self, authed_client):
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.post.return_value = _make_http_response(
+                500, {"detail": "Internal server error"}
+            )
+            response = authed_client.post(
+                "/get-recommendations", data={"location": "London"}
+            )
+        assert response.status_code == 200
+        assert b"Error" in response.content or b"error" in response.content
+
+    def test_empty_recommendations_shows_no_results_message(self, authed_client):
+        empty_resp = {
+            **MOCK_BACKEND_RECOMMENDATIONS_RESPONSE,
+            "recommendations": [],
+            "count": 0,
+        }
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.post.return_value = _make_http_response(200, empty_resp)
+            response = authed_client.post(
+                "/get-recommendations", data={"location": "London"}
+            )
+        assert response.status_code == 200
+        assert b"No recommendations" in response.content
+
+    def test_network_error_shows_connection_error(self, authed_client):
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.post.side_effect = Exception("Connection refused")
+            response = authed_client.post(
+                "/get-recommendations", data={"location": "London"}
+            )
+        assert response.status_code == 200
+        assert (
+            b"Connection error" in response.content
+            or b"could not reach" in response.content
+        )
+
+    def test_sends_bearer_token_to_backend(self, authed_client):
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.post.return_value = _make_http_response(
+                200, MOCK_BACKEND_RECOMMENDATIONS_RESPONSE
+            )
+            authed_client.post("/get-recommendations", data={"location": "London"})
+
+        call_kwargs = mock_instance.post.call_args
+        headers = call_kwargs[1].get("headers", {})
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("Bearer ")
+
+    def test_sends_correct_json_body_to_backend(self, authed_client):
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.post.return_value = _make_http_response(
+                200, MOCK_BACKEND_RECOMMENDATIONS_RESPONSE
+            )
+            authed_client.post("/get-recommendations", data={"location": "Paris"})
+
+        call_kwargs = mock_instance.post.call_args
+        payload = call_kwargs[1].get("json", {})
+        assert payload.get("location") == "Paris"
+        assert payload.get("include_explanation") is False
+
+    def test_product_card_placeholder_shown_when_no_image(self, authed_client):
+        """Items without image_url render the placeholder emoji."""
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.post.return_value = _make_http_response(
+                200, MOCK_BACKEND_RECOMMENDATIONS_RESPONSE
+            )
+            response = authed_client.post(
+                "/get-recommendations", data={"location": "London"}
+            )
+        assert response.status_code == 200
+        # White Oxford Shirt has no image_url — placeholder div should appear
+        assert b"product-card-placeholder" in response.content


### PR DESCRIPTION
…s frontend

- Add encode_image() to embedding_service using CLIP ViT-B/32 image encoder; triggered as fire-and-forget after wardrobe photo upload to populate wardrobe_items.embedding (EC2 only; lazy import keeps Lambda under 250MB)
- Add scripts/backfill_wardrobe_embeddings.py for batch backfill of existing wardrobe photos (idempotent; --batch-size/--dry-run/--limit flags)
- Add GET /recommendations page and POST /get-recommendations HTMX endpoint in frontend; calls POST /recommend-products and renders product card grid
- Add "Get Recommendations" shop button to outfit results (logged-in only)
- Add "Recs" nav link for authenticated users
- Update plan.md and docs/two_tower_rec_system.md to reflect completed work and document image embedding architecture (Section 21)
- 40 frontend tests, 10 embedding service tests — all passing