### PR TITLE
feat: add PUT /wardrobe/{item_id} to complete Wardrobe CRUD API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -808,29 +808,45 @@ async def update_wardrobe_item_endpoint(
     """
     Update name, category, and/or tags on a wardrobe item.
 
-    All fields are optional — only provided fields are changed (PATCH semantics
-    via PUT).  Ownership is enforced: 404 when the item doesn't exist or belongs
-    to a different user.
+    All fields are optional — only provided fields are changed (partial update
+    semantics).  At least one field must be non-null; an empty body returns 422.
+    Ownership is enforced: 404 when the item doesn't exist or belongs to a
+    different user.
     """
     from app.services import wardrobe_service
     from app.services.storage_service import get_image_presigned_url
     from app.models.wardrobe import WardrobeItemResponse
 
-    item = await wardrobe_service.update_wardrobe_item(
-        user_id=user_id,
-        item_id=item_id,
-        name=body.name,
-        category=body.category,
-        tags=body.tags,
-    )
+    try:
+        item = await wardrobe_service.update_wardrobe_item(
+            user_id=user_id,
+            item_id=item_id,
+            name=body.name,
+            category=body.category,
+            tags=body.tags,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        )
+
     if item is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Wardrobe item not found"
         )
 
-    image_url = (
-        get_image_presigned_url(item["image_s3_key"]) if item["image_s3_key"] else None
-    )
+    try:
+        image_url = (
+            get_image_presigned_url(item["image_s3_key"])
+            if item["image_s3_key"]
+            else None
+        )
+    except Exception:
+        logger.error(
+            "PUT /wardrobe/%s: failed to generate presigned URL", item_id, exc_info=True
+        )
+        image_url = None
+
     logger.info("PUT /wardrobe/%s: updated by user_id=%s", item_id, user_id)
     return WardrobeItemResponse(
         item_id=item["item_id"],

--- a/app/models/wardrobe.py
+++ b/app/models/wardrobe.py
@@ -1,25 +1,25 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict
+
+CategoryType = Literal["tops", "bottoms", "outerwear", "shoes", "accessories"]
 
 
 class WardrobeItemCreate(BaseModel):
     """Request body for creating a new wardrobe item (metadata only; image is multipart)."""
 
     name: str
-    category: Optional[str] = (
-        None  # 'tops' | 'bottoms' | 'outerwear' | 'shoes' | 'accessories'
-    )
+    category: Optional[CategoryType] = None
 
 
 class WardrobeItemUpdate(BaseModel):
     """Request body for updating wardrobe item metadata (all fields optional)."""
 
     name: Optional[str] = None
-    category: Optional[str] = None
+    category: Optional[CategoryType] = None
     tags: Optional[list[str]] = None
 
 

--- a/app/services/wardrobe_service.py
+++ b/app/services/wardrobe_service.py
@@ -199,8 +199,10 @@ async def update_wardrobe_item(
     Update mutable metadata on a wardrobe item, enforcing ownership.
 
     Only the fields explicitly passed (non-None) are updated; omitted fields
-    retain their current database values.  Returns the updated row as a dict,
-    or ``None`` if the item does not exist or is not owned by ``user_id``.
+    retain their current database values.  Raises ``ValueError`` if all three
+    fields are None (callers should surface this as HTTP 422).  Returns the
+    updated row as a dict, or ``None`` if the item does not exist or is not
+    owned by ``user_id``.
 
     Args:
         user_id: UUID of the requesting user.
@@ -214,7 +216,7 @@ async def update_wardrobe_item(
         success; ``None`` if the item was not found or is not owned by the user.
     """
     set_clauses: list[str] = []
-    params: list = []
+    params: list[object] = []
 
     if name is not None:
         set_clauses.append("name = %s")
@@ -227,9 +229,9 @@ async def update_wardrobe_item(
         params.append(tags)
 
     if not set_clauses:
-        return await get_wardrobe_item(user_id, item_id)
+        raise ValueError("At least one field (name, category, tags) must be provided.")
 
-    sql = f"""
+    update_sql = f"""
         UPDATE wardrobe_items
         SET {', '.join(set_clauses)}
         WHERE item_id = %s AND user_id = %s
@@ -239,7 +241,7 @@ async def update_wardrobe_item(
 
     async with get_connection() as conn:
         async with conn.cursor() as cur:
-            await cur.execute(sql, params)
+            await cur.execute(update_sql, params)
             row = await cur.fetchone()
             await conn.commit()
 

--- a/tests/test_wardrobe_service.py
+++ b/tests/test_wardrobe_service.py
@@ -279,6 +279,7 @@ class TestUpdateWardrobeItem:
             )
 
         assert result is not None
+        assert result["item_id"] == str(_ITEM_ID)
         assert result["name"] == "Updated Blazer"
         assert result["category"] == "tops"
         assert result["tags"] == ["blue"]
@@ -309,7 +310,7 @@ class TestUpdateWardrobeItem:
         mock_conn.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_where_clause_includes_user_id(self):
+    async def test_where_clause_includes_user_id_and_executes_update(self):
         mock_conn, mock_cur = _make_mock_conn(fetchone_return=None)
 
         with patch(_PATCH_CONN, return_value=_mock_get_connection(mock_conn)):
@@ -318,6 +319,25 @@ class TestUpdateWardrobeItem:
             )
 
         mock_cur.execute.assert_awaited_once()
-        params = mock_cur.execute.call_args[0][1]
+        call_sql, params = mock_cur.execute.call_args[0]
+        # Ownership check: both IDs must appear in the WHERE clause parameters
         assert str(_ITEM_ID) in params
         assert _USER_ID in params
+        # Must be an UPDATE, not a SELECT (distinguishes from the empty-body fallback path)
+        assert "UPDATE" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_empty_body_raises_value_error(self):
+        """All-None fields must raise ValueError — callers surface this as HTTP 422."""
+        mock_conn, mock_cur = _make_mock_conn()
+
+        with patch(_PATCH_CONN, return_value=_mock_get_connection(mock_conn)):
+            with pytest.raises(ValueError, match="At least one field"):
+                await wardrobe_service.update_wardrobe_item(
+                    user_id=_USER_ID,
+                    item_id=str(_ITEM_ID),
+                    # name, category, tags all default to None
+                )
+
+        # No DB query should have been executed
+        mock_cur.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Adds `WardrobeItemUpdate` Pydantic model with optional `name`, `category`, `tags` fields; `category` validated against `Literal` type to reject invalid values at request time
- Adds `wardrobe_service.update_wardrobe_item()` with dynamic SET clause (only updates provided fields), ownership enforcement (`AND user_id = %s`), and `ValueError` on all-None body
- Adds `PUT /wardrobe/{item_id}` endpoint: JWT auth required, HTTP 422 on empty body, HTTP 404 on missing/other-user item, returns `WardrobeItemResponse` with presigned image URL
- 5 unit tests (success, not-found, commit, ownership/UPDATE assertion, empty-body ValueError)

Closes #43

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_wardrobe_service.py -v` — 19 passed
- [x] `PYTHONPATH=. pytest tests/ -v` — 611 passed, 0 failed