### PR TITLE
feat: local GPU embedding server to offload CLIP from EC2 t4g.micro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Fitted — local dev helpers
 # Requires: SSH tunnel open (make tunnel) and venv active
+# To offload CLIP to local GPU: make embed-server  (then in separate terminal: make tunnel-embed)
 
 PYTHON := .venv/bin/python
 # Fetch DB URL from SSM at runtime and rewrite host to localhost (SSH tunnel)
@@ -9,9 +10,18 @@ RUN      := USE_SSM=true DATABASE_URL="$(DB_URL)" PYTHONPATH=. $(PYTHON)
 
 # ── Tunnel ────────────────────────────────────────────────────────────────────
 
-.PHONY: tunnel
+EC2_HOST ?= fitted
+
+.PHONY: tunnel tunnel-embed embed-server
+
 tunnel:
-	ssh fitted-db-tunnel -N
+	ssh $(EC2_HOST) -N -L 5432:localhost:5432
+
+tunnel-embed:
+	ssh -R 8001:localhost:8001 $(EC2_HOST)
+
+embed-server:
+	$(PYTHON) scripts/embedding_server.py $(ARGS)
 
 # ── ML scripts ────────────────────────────────────────────────────────────────
 

--- a/app/services/embedding_service.py
+++ b/app/services/embedding_service.py
@@ -2,6 +2,7 @@
 
 import io
 import logging
+import os
 
 import numpy as np
 
@@ -48,6 +49,9 @@ def encode_text(text: str) -> np.ndarray:
     Returns:
         np.ndarray of shape (512,), dtype float32, unit norm.
     """
+    if _remote_url():
+        return _remote_encode_text(text)
+
     import torch
 
     model, tokenizer, _ = _load_model_and_transform()
@@ -84,6 +88,24 @@ def encode_image(url_or_s3_key: str) -> np.ndarray:
     Returns:
         np.ndarray of shape (512,), dtype float32, unit norm.
     """
+    if _remote_url():
+        # Fetch image bytes on EC2 (AWS creds stay server-side), send only bytes to remote
+        if url_or_s3_key.startswith("http"):
+            import requests
+
+            response = requests.get(url_or_s3_key, timeout=10)
+            response.raise_for_status()
+            image_bytes = response.content
+        else:
+            import boto3
+            import os as _os
+
+            s3 = boto3.client("s3")
+            bucket = _os.environ.get("S3_BUCKET", "fitted-wardrobe-images")
+            obj = s3.get_object(Bucket=bucket, Key=url_or_s3_key)
+            image_bytes = obj["Body"].read()
+        return _remote_encode_image(image_bytes)
+
     import torch
     from PIL import Image
 
@@ -130,3 +152,42 @@ def reset_model_for_testing() -> None:
     _model = None
     _tokenizer = None
     _transform = None
+
+
+def _remote_url() -> str | None:
+    """Return the remote embedding server base URL, or None if not configured."""
+    return os.environ.get("EMBEDDING_SERVICE_URL")
+
+
+def _remote_encode_text(text: str) -> np.ndarray:
+    """POST text to the remote embedding server and return a 512-dim float32 ndarray."""
+    import httpx
+
+    url = _remote_url()
+    resp = httpx.post(f"{url}/embed/text", json={"text": text}, timeout=30.0)
+    resp.raise_for_status()
+    embedding = np.array(resp.json()["embedding"], dtype=np.float32)
+    logger.debug(
+        "_remote_encode_text: %r -> shape %s (remote)", text[:80], embedding.shape
+    )
+    return embedding
+
+
+def _remote_encode_image(image_bytes: bytes) -> np.ndarray:
+    """POST raw image bytes to the remote embedding server and return a 512-dim float32 ndarray."""
+    import httpx
+
+    url = _remote_url()
+    resp = httpx.post(
+        f"{url}/embed/image",
+        files={"file": ("image.jpg", image_bytes, "image/jpeg")},
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    embedding = np.array(resp.json()["embedding"], dtype=np.float32)
+    logger.debug(
+        "_remote_encode_image: %d bytes -> shape %s (remote)",
+        len(image_bytes),
+        embedding.shape,
+    )
+    return embedding

--- a/app/services/embedding_service.py
+++ b/app/services/embedding_service.py
@@ -98,10 +98,9 @@ def encode_image(url_or_s3_key: str) -> np.ndarray:
             image_bytes = response.content
         else:
             import boto3
-            import os as _os
 
             s3 = boto3.client("s3")
-            bucket = _os.environ.get("S3_BUCKET", "fitted-wardrobe-images")
+            bucket = os.environ.get("S3_BUCKET", "fitted-wardrobe-images")
             obj = s3.get_object(Bucket=bucket, Key=url_or_s3_key)
             image_bytes = obj["Body"].read()
         return _remote_encode_image(image_bytes)
@@ -123,8 +122,6 @@ def encode_image(url_or_s3_key: str) -> np.ndarray:
 
         logger.debug("encode_image: fetching S3 key %s", url_or_s3_key)
         s3 = boto3.client("s3")
-        import os
-
         bucket = os.environ.get("S3_BUCKET", "fitted-wardrobe-images")
         obj = s3.get_object(Bucket=bucket, Key=url_or_s3_key)
         image_bytes = obj["Body"].read()
@@ -155,8 +152,24 @@ def reset_model_for_testing() -> None:
 
 
 def _remote_url() -> str | None:
-    """Return the remote embedding server base URL, or None if not configured."""
-    return os.environ.get("EMBEDDING_SERVICE_URL")
+    """Return the remote embedding server base URL, or None if not configured.
+
+    Raises ValueError at call time if the URL targets a disallowed host (e.g.,
+    EC2 instance metadata endpoint) to prevent SSRF.
+    """
+    import urllib.parse
+
+    url = os.environ.get("EMBEDDING_SERVICE_URL")
+    if url is None:
+        return None
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"EMBEDDING_SERVICE_URL must use http or https, got: {url!r}")
+    if parsed.hostname in ("169.254.169.254", "fd00:ec2::254"):
+        raise ValueError(
+            "EMBEDDING_SERVICE_URL must not target the EC2 instance metadata endpoint"
+        )
+    return url
 
 
 def _remote_encode_text(text: str) -> np.ndarray:
@@ -167,6 +180,10 @@ def _remote_encode_text(text: str) -> np.ndarray:
     resp = httpx.post(f"{url}/embed/text", json={"text": text}, timeout=30.0)
     resp.raise_for_status()
     embedding = np.array(resp.json()["embedding"], dtype=np.float32)
+    if embedding.shape != (512,):
+        raise ValueError(
+            f"Remote embedding server returned unexpected shape {embedding.shape}; expected (512,)"
+        )
     logger.debug(
         "_remote_encode_text: %r -> shape %s (remote)", text[:80], embedding.shape
     )
@@ -185,6 +202,10 @@ def _remote_encode_image(image_bytes: bytes) -> np.ndarray:
     )
     resp.raise_for_status()
     embedding = np.array(resp.json()["embedding"], dtype=np.float32)
+    if embedding.shape != (512,):
+        raise ValueError(
+            f"Remote embedding server returned unexpected shape {embedding.shape}; expected (512,)"
+        )
     logger.debug(
         "_remote_encode_image: %d bytes -> shape %s (remote)",
         len(image_bytes),

--- a/infra/systemd/fitted-backend.service
+++ b/infra/systemd/fitted-backend.service
@@ -13,6 +13,11 @@ RestartSec=10
 Environment="USE_SSM=true"
 Environment="AWS_DEFAULT_REGION=us-west-1"
 Environment="WEATHER_BUCKET_NAME=fitted-weather-data-fitted-wardrobe-dev-903558039846"
+# Uncomment to offload CLIP embeddings to a local GPU machine via SSH reverse tunnel.
+# 1. Start local server:  python scripts/embedding_server.py
+# 2. Open tunnel (local): ssh -R 8001:localhost:8001 ec2-user@<EC2_IP>
+# 3. Uncomment the line below and restart: sudo systemctl restart fitted-backend
+#Environment="EMBEDDING_SERVICE_URL=http://localhost:8001"
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/embedding_server.py
+++ b/scripts/embedding_server.py
@@ -1,0 +1,118 @@
+"""Local CLIP embedding server — run on your GPU machine, tunnel to EC2.
+
+Usage:
+    python scripts/embedding_server.py           # port 8001
+    python scripts/embedding_server.py --port 9000
+
+SSH tunnel (on local machine):
+    ssh -R 8001:localhost:8001 ec2-user@<EC2_IP>
+
+Then set on EC2 systemd service:
+    Environment="EMBEDDING_SERVICE_URL=http://localhost:8001"
+"""
+
+import argparse
+import io
+import logging
+import threading
+
+import numpy as np
+import uvicorn
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Fitted Embedding Server")
+
+# Module-level singletons
+_model = None
+_tokenizer = None
+_transform = None
+_CLIP_MODEL = "ViT-B-32"
+_CLIP_PRETRAINED = "laion400m_e32"
+_load_lock = threading.Lock()
+
+
+def _load_model():
+    global _model, _tokenizer, _transform
+    if _model is not None:
+        return _model, _tokenizer, _transform
+    with _load_lock:
+        if _model is not None:
+            return _model, _tokenizer, _transform
+        import open_clip
+
+        logger.info("Loading CLIP model %s...", _CLIP_MODEL)
+        model, _, preprocess_val = open_clip.create_model_and_transforms(
+            _CLIP_MODEL, pretrained=_CLIP_PRETRAINED
+        )
+        model.eval()
+        tokenizer = open_clip.get_tokenizer(_CLIP_MODEL)
+        _model, _tokenizer, _transform = model, tokenizer, preprocess_val
+        logger.info("CLIP model loaded.")
+    return _model, _tokenizer, _transform
+
+
+class TextRequest(BaseModel):
+    text: str
+
+
+@app.post("/embed/text")
+def embed_text(req: TextRequest) -> JSONResponse:
+    """Encode a text string and return a 512-dim L2-normalized embedding."""
+    import torch
+
+    model, tokenizer, _ = _load_model()
+    tokens = tokenizer([req.text])
+    with torch.no_grad():
+        features = model.encode_text(tokens)
+        features = features / features.norm(dim=-1, keepdim=True)
+    embedding: list[float] = features.cpu().numpy().astype(np.float32)[0].tolist()
+    logger.debug("embed_text: %r -> shape (512,)", req.text[:80])
+    return JSONResponse({"embedding": embedding})
+
+
+@app.post("/embed/image")
+def embed_image(file: UploadFile = File(...)) -> JSONResponse:
+    """Encode raw image bytes and return a 512-dim L2-normalized embedding."""
+    import torch
+    from PIL import Image
+
+    model, _, transform = _load_model()
+    image_bytes = file.file.read()
+    try:
+        image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+    except Exception as exc:
+        logger.warning(
+            "embed_image: failed to decode image (%d bytes): %s", len(image_bytes), exc
+        )
+        return JSONResponse({"error": "Could not decode image bytes"}, status_code=422)
+    tensor = transform(image).unsqueeze(0)
+    with torch.no_grad():
+        features = model.encode_image(tensor)
+        features = features / features.norm(dim=-1, keepdim=True)
+    embedding: list[float] = features.cpu().numpy().astype(np.float32)[0].tolist()
+    logger.debug("embed_image: %d bytes -> shape (512,)", len(image_bytes))
+    return JSONResponse({"embedding": embedding})
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok", "model_loaded": _model is not None}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=8001)
+    parser.add_argument("--host", default="127.0.0.1")
+    args = parser.parse_args()
+    if args.host != "127.0.0.1":
+        logger.warning(
+            "SECURITY: Binding to %s with no authentication. "
+            "Only do this inside a trusted network.",
+            args.host,
+        )
+    uvicorn.run(app, host=args.host, port=args.port)

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -5,12 +5,14 @@ or loaded in CI.
 """
 
 import io
+import os
 import numpy as np
 import pytest
 import torch
 from unittest.mock import MagicMock, patch
 
 from app.services.embedding_service import reset_model_for_testing
+from app.services import embedding_service
 
 
 @pytest.fixture(autouse=True)
@@ -84,6 +86,68 @@ def test_encode_text_l2_normalizes_output():
         result = encode_text("any text")
 
     assert abs(np.linalg.norm(result) - 1.0) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Remote embedding client path
+# ---------------------------------------------------------------------------
+
+
+def test_encode_text_uses_remote_when_env_var_set():
+    """When EMBEDDING_SERVICE_URL is set, encode_text should POST to the remote server."""
+    fake_embedding = [0.1] * 512
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"embedding": fake_embedding}
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.dict(os.environ, {"EMBEDDING_SERVICE_URL": "http://localhost:8001"}):
+        with patch("httpx.post", return_value=mock_response) as mock_post:
+            result = embedding_service.encode_text("blue shirt")
+
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    assert "/embed/text" in call_args.args[0]
+    assert result.shape == (512,)
+    assert result.dtype == np.float32
+
+
+def test_encode_text_uses_local_when_env_var_absent():
+    """When EMBEDDING_SERVICE_URL is not set, encode_text should use local CLIP."""
+    env = {k: v for k, v in os.environ.items() if k != "EMBEDDING_SERVICE_URL"}
+    with patch.dict(os.environ, env, clear=True):
+        with patch(
+            "app.services.embedding_service._load_model_and_transform",
+            return_value=(_make_mock_model(), _make_mock_tokenizer(), MagicMock()),
+        ) as mock_load:
+            from app.services.embedding_service import encode_text
+
+            encode_text("test")
+        mock_load.assert_called_once()
+
+
+def test_encode_image_sends_bytes_to_remote():
+    """When EMBEDDING_SERVICE_URL is set, encode_image fetches bytes locally and POSTs them."""
+    fake_embedding = [0.5] * 512
+    mock_httpx_response = MagicMock()
+    mock_httpx_response.json.return_value = {"embedding": fake_embedding}
+    mock_httpx_response.raise_for_status = MagicMock()
+
+    fake_jpeg = b"\xff\xd8\xff" + b"\x00" * 100
+
+    mock_requests_response = MagicMock()
+    mock_requests_response.content = fake_jpeg
+    mock_requests_response.raise_for_status = MagicMock()
+
+    with patch.dict(os.environ, {"EMBEDDING_SERVICE_URL": "http://localhost:8001"}):
+        with patch("requests.get", return_value=mock_requests_response):
+            with patch("httpx.post", return_value=mock_httpx_response) as mock_post:
+                result = embedding_service.encode_image("https://example.com/img.jpg")
+
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    assert "/embed/image" in call_args.args[0]
+    assert result.shape == (512,)
+    assert result.dtype == np.float32
 
 
 def test_encode_text_returns_float32():
@@ -195,10 +259,13 @@ def test_encode_image_url_returns_512_dim_unit_vector():
     mock_response.content = fake_jpeg
     mock_response.raise_for_status = MagicMock()
 
-    with patch(
-        "app.services.embedding_service._load_model_and_transform",
-        return_value=(mock_model, _make_mock_tokenizer(), mock_transform),
-    ), patch("requests.get", return_value=mock_response):
+    with (
+        patch(
+            "app.services.embedding_service._load_model_and_transform",
+            return_value=(mock_model, _make_mock_tokenizer(), mock_transform),
+        ),
+        patch("requests.get", return_value=mock_response),
+    ):
         from app.services.embedding_service import encode_image
 
         result = encode_image("https://example.com/shirt.jpg")
@@ -219,10 +286,13 @@ def test_encode_image_s3_key_fetches_from_s3():
     mock_body.read.return_value = fake_jpeg
     mock_s3_client.get_object.return_value = {"Body": mock_body}
 
-    with patch(
-        "app.services.embedding_service._load_model_and_transform",
-        return_value=(mock_model, _make_mock_tokenizer(), mock_transform),
-    ), patch("boto3.client", return_value=mock_s3_client):
+    with (
+        patch(
+            "app.services.embedding_service._load_model_and_transform",
+            return_value=(mock_model, _make_mock_tokenizer(), mock_transform),
+        ),
+        patch("boto3.client", return_value=mock_s3_client),
+    ):
         from app.services.embedding_service import encode_image
 
         result = encode_image("wardrobe-images/user-123/item-456.jpg")
@@ -245,10 +315,13 @@ def test_encode_image_url_is_l2_normalized():
     mock_response.content = fake_jpeg
     mock_response.raise_for_status = MagicMock()
 
-    with patch(
-        "app.services.embedding_service._load_model_and_transform",
-        return_value=(mock_model, _make_mock_tokenizer(), mock_transform),
-    ), patch("requests.get", return_value=mock_response):
+    with (
+        patch(
+            "app.services.embedding_service._load_model_and_transform",
+            return_value=(mock_model, _make_mock_tokenizer(), mock_transform),
+        ),
+        patch("requests.get", return_value=mock_response),
+    ):
         from app.services.embedding_service import encode_image
 
         result = encode_image("https://example.com/pants.jpg")

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -327,3 +327,28 @@ def test_encode_image_url_is_l2_normalized():
         result = encode_image("https://example.com/pants.jpg")
 
     assert abs(np.linalg.norm(result) - 1.0) < 1e-5
+
+
+def test_encode_image_s3_key_sends_bytes_to_remote():
+    """When EMBEDDING_SERVICE_URL is set and an S3 key is given, encode_image fetches from S3 and POSTs bytes."""
+    fake_embedding = [0.5] * 512
+    mock_httpx_response = MagicMock()
+    mock_httpx_response.json.return_value = {"embedding": fake_embedding}
+    mock_httpx_response.raise_for_status = MagicMock()
+    fake_jpeg = b"\xff\xd8\xff" + b"\x00" * 100
+
+    mock_s3_client = MagicMock()
+    mock_body = MagicMock()
+    mock_body.read.return_value = fake_jpeg
+    mock_s3_client.get_object.return_value = {"Body": mock_body}
+
+    with patch.dict(os.environ, {"EMBEDDING_SERVICE_URL": "http://localhost:8001"}):
+        with patch("boto3.client", return_value=mock_s3_client):
+            with patch("httpx.post", return_value=mock_httpx_response) as mock_post:
+                result = embedding_service.encode_image("wardrobe-images/user/item.jpg")
+
+    mock_s3_client.get_object.assert_called_once()
+    mock_post.assert_called_once()
+    assert "/embed/image" in mock_post.call_args.args[0]
+    assert result.shape == (512,)
+    assert result.dtype == np.float32


### PR DESCRIPTION
## Summary

- Adds `scripts/embedding_server.py` — a standalone FastAPI CLIP ViT-B/32 server that runs on a local GPU machine and serves `/embed/text`, `/embed/image`, `/health`
- Adds remote client path to `app/services/embedding_service.py` — when `EMBEDDING_SERVICE_URL` is set, embedding calls POST to the remote server instead of loading CLIP locally; S3/URL fetching stays on EC2 so AWS credentials never leave the server
- Documents `EMBEDDING_SERVICE_URL` in `infra/systemd/fitted-backend.service` with SSH tunnel instructions (commented out by default)

Closes #54

## How to use

```bash
# 1. Start local embedding server (on your GPU machine)
python scripts/embedding_server.py

# 2. Open SSH reverse tunnel (keep terminal open)
ssh -R 8001:localhost:8001 ec2-user@<EC2_IP>

# 3. On EC2 — uncomment in /etc/systemd/system/fitted-backend.service:
#    Environment="EMBEDDING_SERVICE_URL=http://localhost:8001"
sudo systemctl daemon-reload && sudo systemctl restart fitted-backend
```

## Security

- `EMBEDDING_SERVICE_URL` is validated at call time: must use `http`/`https`, blocks EC2 metadata endpoint (`169.254.169.254`)
- Server defaults to `127.0.0.1` binding; logs a warning if started with `--host 0.0.0.0`
- Thread-safe CLIP model loading (double-checked locking)

## Test plan

- [ ] 634 tests passing (`PYTHONPATH=. pytest tests/ -q`)
- [ ] 4 new remote-path tests in `tests/test_embedding_service.py`
- [ ] Manual: start server locally, open tunnel, upload wardrobe image, confirm EC2 logs show no CLIP load and local server logs show embed request