### PR TITLE
feat: wardrobe image embedding status tracking

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -945,7 +945,6 @@ async def add_wardrobe_item(
     )
 
     if image_s3_key:
-        import asyncio
         asyncio.create_task(
             wardrobe_service.embed_wardrobe_item(item["item_id"], image_s3_key)
         )

--- a/app/main.py
+++ b/app/main.py
@@ -36,6 +36,7 @@ from pydantic import BaseModel, Field
 from pydantic import StringConstraints
 from app.services import weather_service
 from app.services import llm_service
+from app.services import wardrobe_service
 from app.core.config import config
 from app.services import analysis_service
 from app.services import user_service
@@ -867,7 +868,6 @@ async def list_wardrobe(
 
     Each item includes a presigned S3 URL (1 h expiry) when an image exists.
     """
-    from app.services import wardrobe_service
     from app.services.storage_service import get_image_presigned_url
     from app.models.wardrobe import WardrobeItemResponse
 
@@ -885,6 +885,7 @@ async def list_wardrobe(
                 image_url=image_url,
                 tags=item["tags"],
                 created_at=item["created_at"],
+                embedding_status=item["embedding_status"],
             ).model_dump()
         )
 
@@ -907,7 +908,6 @@ async def add_wardrobe_item(
     ``wardrobe-images/{user_id}/{item_id}.jpg``; the S3 key is stored on the row.
     The CLIP embedding column is NULL until the wardrobe backfill script runs.
     """
-    from app.services import wardrobe_service
     from app.services.storage_service import (
         upload_wardrobe_image,
         get_image_presigned_url,
@@ -946,28 +946,9 @@ async def add_wardrobe_item(
 
     if image_s3_key:
         import asyncio
-
-        async def _embed_wardrobe_image(item_id: str, s3_key: str) -> None:
-            try:
-                from app.services.embedding_service import encode_image
-
-                vec = encode_image(s3_key)
-                async with db_service.get_connection() as conn:
-                    async with conn.cursor() as cur:
-                        await cur.execute(
-                            "UPDATE wardrobe_items SET embedding = %s::vector WHERE item_id = %s",
-                            (vec.tolist(), item_id),
-                        )
-                        await conn.commit()
-                logger.info("Wardrobe image embedded: item_id=%s", item_id)
-            except Exception:
-                logger.error(
-                    "Failed to embed wardrobe image: item_id=%s",
-                    item_id,
-                    exc_info=True,
-                )
-
-        asyncio.create_task(_embed_wardrobe_image(item["item_id"], image_s3_key))
+        asyncio.create_task(
+            wardrobe_service.embed_wardrobe_item(item["item_id"], image_s3_key)
+        )
 
     image_url = get_image_presigned_url(image_s3_key) if image_s3_key else None
     return WardrobeItemResponse(
@@ -977,6 +958,7 @@ async def add_wardrobe_item(
         image_url=image_url,
         tags=item["tags"],
         created_at=item["created_at"],
+        embedding_status=item["embedding_status"],
     ).model_dump()
 
 
@@ -991,8 +973,6 @@ async def delete_wardrobe_item(
     Ownership is enforced: users can only delete their own items.  Returns 404
     when the item does not exist or belongs to a different user.
     """
-    from app.services import wardrobe_service
-
     deleted = await wardrobe_service.delete_wardrobe_item(
         user_id=user_id, item_id=item_id
     )
@@ -1017,7 +997,6 @@ async def update_wardrobe_item_endpoint(
     Ownership is enforced: 404 when the item doesn't exist or belongs to a
     different user.
     """
-    from app.services import wardrobe_service
     from app.services.storage_service import get_image_presigned_url
     from app.models.wardrobe import WardrobeItemResponse
 
@@ -1059,7 +1038,45 @@ async def update_wardrobe_item_endpoint(
         image_url=image_url,
         tags=item["tags"],
         created_at=item["created_at"],
+        embedding_status=item["embedding_status"],
     ).model_dump()
+
+
+@app.get("/wardrobe/{item_id}/status")
+async def get_wardrobe_item_status(
+    item_id: str,
+    request: Request,
+    user_id: str = Depends(auth.get_current_user_id),
+):
+    """
+    Return embedding_status for a wardrobe item.
+
+    When called from HTMX (HX-Request header present), returns an HTML badge
+    partial instead of JSON. Polling stops automatically when the badge for
+    terminal states (done/failed) omits hx-trigger.
+    """
+    from app.models.wardrobe import WardrobeItemStatusResponse
+    from fastapi.responses import HTMLResponse
+
+    status = await wardrobe_service.get_wardrobe_item_status(user_id, item_id)
+    if status is None:
+        raise HTTPException(status_code=404, detail="Wardrobe item not found")
+
+    if request.headers.get("HX-Request"):
+        if status in ("pending", "embedding"):
+            html = (
+                f'<span id="embed-status-{item_id}" '
+                f'hx-get="/wardrobe/{item_id}/status" '
+                f'hx-trigger="every 2s" hx-target="this" hx-swap="outerHTML" '
+                f'class="badge badge-pending">⏳ {status}</span>'
+            )
+        elif status == "done":
+            html = f'<span id="embed-status-{item_id}" class="badge badge-done">✓ ready</span>'
+        else:
+            html = f'<span id="embed-status-{item_id}" class="badge badge-failed">✗ failed</span>'
+        return HTMLResponse(content=html)
+
+    return WardrobeItemStatusResponse(item_id=item_id, embedding_status=status)
 
 
 # --- Interaction Logging Endpoints ---

--- a/app/services/wardrobe_service.py
+++ b/app/services/wardrobe_service.py
@@ -276,6 +276,26 @@ async def update_wardrobe_item(
     }
 
 
+async def get_wardrobe_item_status(user_id: str, item_id: str) -> Optional[str]:
+    """
+    Return the embedding_status for a wardrobe item, enforcing ownership.
+
+    Returns the status string ('pending', 'embedding', 'done', 'failed'),
+    or None if the item doesn't exist or is not owned by user_id.
+    """
+    async with get_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "SELECT embedding_status FROM wardrobe_items WHERE item_id = %s AND user_id = %s",
+                (item_id, user_id),
+            )
+            row = await cur.fetchone()
+
+    if row is None:
+        return None
+    return row[0]
+
+
 async def embed_wardrobe_item(item_id: str, s3_key: str) -> None:
     """
     Encode the wardrobe item image at s3_key with CLIP and persist the embedding.

--- a/app/services/wardrobe_service.py
+++ b/app/services/wardrobe_service.py
@@ -274,3 +274,51 @@ async def update_wardrobe_item(
         "created_at": created_at,
         "embedding_status": emb_status,
     }
+
+
+async def embed_wardrobe_item(item_id: str, s3_key: str) -> None:
+    """
+    Encode the wardrobe item image at s3_key with CLIP and persist the embedding.
+
+    Sets embedding_status to 'embedding' before starting, then 'done' on
+    success or 'failed' on any exception. Offloads the synchronous encode_image
+    call to a thread pool executor to avoid blocking the event loop.
+    """
+    from app.services.embedding_service import encode_image
+
+    async with get_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "UPDATE wardrobe_items SET embedding_status = 'embedding' WHERE item_id = %s",
+                (item_id,),
+            )
+        await conn.commit()
+
+    try:
+        loop = asyncio.get_running_loop()
+        vec = await loop.run_in_executor(None, encode_image, s3_key)
+
+        async with get_connection() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "UPDATE wardrobe_items SET embedding = %s::vector, embedding_status = 'done' WHERE item_id = %s",
+                    (vec.tolist(), item_id),
+                )
+            await conn.commit()
+
+    except Exception:
+        try:
+            async with get_connection() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        "UPDATE wardrobe_items SET embedding_status = 'failed' WHERE item_id = %s",
+                        (item_id,),
+                    )
+                await conn.commit()
+        except Exception:
+            logger.error(
+                "embed_wardrobe_item: failed to set failed status: item_id=%s",
+                item_id,
+                exc_info=True,
+            )
+        raise

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -368,6 +368,17 @@ custom_css = Style(
         width: 100%;
     }
     .wardrobe-card-delete:hover { background-color: #fef2f2; }
+    .badge {
+        display: inline-block;
+        font-size: 0.7rem;
+        padding: 0.15rem 0.4rem;
+        border-radius: 3px;
+        margin-bottom: 0.25rem;
+        font-weight: bold;
+    }
+    .badge-pending { background: #fef9c3; color: #854d0e; border: 1px solid #fde047; }
+    .badge-done    { background: #dcfce7; color: #166534; border: 1px solid #86efac; }
+    .badge-failed  { background: #fee2e2; color: #991b1b; border: 1px solid #fca5a5; }
     .wardrobe-empty {
         text-align: center;
         color: #64748b;
@@ -1152,13 +1163,33 @@ def wardrobe_card(item: dict) -> Div:
     """A single wardrobe item card with thumbnail and delete button."""
     item_id = item["item_id"]
     image_url = item.get("image_url")
+    embedding_status = item.get("embedding_status", "pending")
+
     thumbnail = (
         Img(src=image_url, alt=item["name"])
         if image_url
         else Div("👔", cls="wardrobe-card-placeholder")
     )
+
+    # Build the status badge
+    if embedding_status in ("pending", "embedding"):
+        status_badge = Span(
+            f"⏳ {embedding_status}",
+            id=f"embed-status-{item_id}",
+            cls="badge badge-pending",
+            hx_get=f"/wardrobe/{item_id}/status",
+            hx_trigger="every 2s",
+            hx_target="this",
+            hx_swap="outerHTML",
+        )
+    elif embedding_status == "done":
+        status_badge = Span("✓ ready", id=f"embed-status-{item_id}", cls="badge badge-done")
+    else:
+        status_badge = Span("✗ failed", id=f"embed-status-{item_id}", cls="badge badge-failed")
+
     return Div(
         thumbnail,
+        status_badge,
         Div(item["name"], cls="wardrobe-card-name"),
         Div(item.get("category") or "—", cls="wardrobe-card-category"),
         Button(

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1382,6 +1382,27 @@ async def wardrobe_delete(item_id: str, session):
     return ""  # HTMX replaces the card element with nothing
 
 
+@app.get("/wardrobe/{item_id}/status")
+async def wardrobe_item_status(item_id: str, session):
+    """HTMX fragment: proxy embedding status badge from backend."""
+    if "access_token" not in session:
+        return ""
+    token = session["access_token"]
+    headers = {"Authorization": f"Bearer {token}", "HX-Request": "true"}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{API_BASE_URL}/wardrobe/{item_id}/status",
+                headers=headers,
+                timeout=5.0,
+            )
+            if resp.status_code == 200:
+                return NotStr(resp.text)
+    except Exception:
+        logger.error("Status poll failed for item_id=%s", item_id, exc_info=True)
+    return ""
+
+
 # --- Interaction Logging (fire-and-forget from product cards) ---
 
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1392,3 +1392,59 @@ class TestAuthRefresh:
             )
 
         assert resp.status_code == 200
+
+
+# ── embedding_status in POST /wardrobe response ───────────────────────────
+
+class TestWardrobeEmbeddingStatus:
+    def test_post_wardrobe_response_includes_embedding_status(self, client, valid_jwt_token):
+        """POST /wardrobe response must include embedding_status field."""
+        from unittest.mock import patch, AsyncMock
+        from datetime import datetime, timezone
+
+        item_dict = {
+            "item_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "name": "Test Blazer",
+            "category": "outerwear",
+            "image_s3_key": None,
+            "tags": [],
+            "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "embedding_status": "pending",
+        }
+        with patch("app.main.wardrobe_service") as mock_ws, \
+             patch("app.main.auth.get_current_user_id", return_value="user-123"):
+            mock_ws.create_wardrobe_item = AsyncMock(return_value=item_dict)
+            resp = client.post(
+                "/wardrobe",
+                data={"name": "Test Blazer"},
+                headers={"Authorization": f"Bearer {valid_jwt_token}"},
+            )
+        assert resp.status_code == 201
+        assert "embedding_status" in resp.json()
+
+    def test_get_wardrobe_item_status_returns_200(self, client, valid_jwt_token):
+        from unittest.mock import patch, AsyncMock
+
+        with patch("app.main.wardrobe_service") as mock_ws, \
+             patch("app.main.auth.get_current_user_id", return_value="user-123"):
+            mock_ws.get_wardrobe_item_status = AsyncMock(return_value="done")
+            resp = client.get(
+                "/wardrobe/some-item-id/status",
+                headers={"Authorization": f"Bearer {valid_jwt_token}"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["item_id"] == "some-item-id"
+        assert body["embedding_status"] == "done"
+
+    def test_get_wardrobe_item_status_returns_404_when_not_found(self, client, valid_jwt_token):
+        from unittest.mock import patch, AsyncMock
+
+        with patch("app.main.wardrobe_service") as mock_ws, \
+             patch("app.main.auth.get_current_user_id", return_value="user-123"):
+            mock_ws.get_wardrobe_item_status = AsyncMock(return_value=None)
+            resp = client.get(
+                "/wardrobe/nonexistent/status",
+                headers={"Authorization": f"Bearer {valid_jwt_token}"},
+            )
+        assert resp.status_code == 404

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -720,3 +720,60 @@ class TestRefreshTokenBeforeware:
         resp = tc.get("/wardrobe")
         assert resp.status_code in (302, 303)
         assert "/login" in resp.headers.get("location", "")
+
+
+# ---------------------------------------------------------------------------
+# GET /wardrobe/{item_id}/status
+# ---------------------------------------------------------------------------
+
+
+class TestWardrobeItemStatus:
+    def test_unauthenticated_returns_empty(self, client):
+        """No access_token in session → route returns empty string."""
+        response = client.get("/wardrobe/item-123/status")
+        assert response.status_code == 200
+        assert response.text == ""
+
+    def test_returns_html_on_backend_200(self, authed_client):
+        """Backend returns 200 with HTML body → route returns that HTML."""
+        html_body = '<span class="badge">ready</span>'
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = html_body
+
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.get.return_value = mock_resp
+            response = authed_client.get("/wardrobe/item-123/status")
+
+        assert response.status_code == 200
+        assert html_body.encode() in response.content
+
+    def test_returns_empty_on_backend_non_200(self, authed_client):
+        """Backend returns 404 → route returns empty string."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_resp.text = "Not Found"
+
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.get.return_value = mock_resp
+            response = authed_client.get("/wardrobe/item-123/status")
+
+        assert response.status_code == 200
+        assert response.text == ""
+
+    def test_returns_empty_on_exception(self, authed_client):
+        """httpx.ConnectError during backend call → route returns empty string."""
+        import httpx as _httpx
+
+        with patch("httpx.AsyncClient") as mock_http:
+            mock_instance = AsyncMock()
+            mock_http.return_value.__aenter__.return_value = mock_instance
+            mock_instance.get.side_effect = _httpx.ConnectError("refused")
+            response = authed_client.get("/wardrobe/item-456/status")
+
+        assert response.status_code == 200
+        assert response.text == ""

--- a/tests/test_wardrobe_service.py
+++ b/tests/test_wardrobe_service.py
@@ -344,3 +344,109 @@ class TestUpdateWardrobeItem:
 
         # No DB query should have been executed
         mock_cur.execute.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# embed_wardrobe_item
+# ---------------------------------------------------------------------------
+
+class TestEmbedWardrobeItem:
+    _ITEM_ID_STR = str(_ITEM_ID)
+    _S3_KEY = "wardrobe-images/user/item.jpg"
+
+    def _make_executor_patch(self, vec, raise_exc=None):
+        """
+        Patch asyncio.get_running_loop so run_in_executor calls encode_image
+        synchronously and returns vec (or raises raise_exc).
+        """
+        mock_loop = MagicMock()
+        if raise_exc:
+            async def fake_executor(executor, fn, *args):
+                raise raise_exc
+        else:
+            async def fake_executor(executor, fn, *args):
+                return vec
+        mock_loop.run_in_executor = fake_executor
+        return patch("asyncio.get_running_loop", return_value=mock_loop)
+
+    @pytest.mark.asyncio
+    async def test_success_sets_embedding_and_done_status(self):
+        import numpy as np
+        vec = np.ones(512, dtype=np.float32)
+        vec /= np.linalg.norm(vec)
+
+        conn1, cur1 = _make_mock_conn()  # SET embedding
+        conn2, cur2 = _make_mock_conn()  # SET done
+        call_iter = [_mock_get_connection(conn1), _mock_get_connection(conn2)]
+        idx = [-1]
+        def next_conn():
+            idx[0] += 1
+            return call_iter[idx[0]]
+
+        with patch(_PATCH_CONN, side_effect=next_conn), \
+             self._make_executor_patch(vec):
+            await wardrobe_service.embed_wardrobe_item(self._ITEM_ID_STR, self._S3_KEY)
+
+        # First DB call: SET embedding_status = 'embedding'
+        sql1, params1 = cur1.execute.call_args[0]
+        assert "embedding_status" in sql1
+        assert "embedding" in sql1
+        conn1.commit.assert_awaited_once()
+
+        # Second DB call: SET embedding + done
+        sql2, params2 = cur2.execute.call_args[0]
+        assert "embedding_status" in sql2
+        assert "done" in sql2
+        assert "::vector" in sql2
+        conn2.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_failure_sets_failed_status_and_reraises(self):
+        conn1, cur1 = _make_mock_conn()  # SET embedding
+        conn2, cur2 = _make_mock_conn()  # SET failed
+        call_iter = [_mock_get_connection(conn1), _mock_get_connection(conn2)]
+        idx = [-1]
+        def next_conn():
+            idx[0] += 1
+            return call_iter[idx[0]]
+
+        exc = RuntimeError("CLIP exploded")
+        with patch(_PATCH_CONN, side_effect=next_conn), \
+             self._make_executor_patch(None, raise_exc=exc):
+            with pytest.raises(RuntimeError, match="CLIP exploded"):
+                await wardrobe_service.embed_wardrobe_item(self._ITEM_ID_STR, self._S3_KEY)
+
+        # Cleanup DB call: SET embedding_status = 'failed'
+        sql2, _ = cur2.execute.call_args[0]
+        assert "failed" in sql2
+        conn2.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_error_is_swallowed_original_reraises(self):
+        """If the failed-status UPDATE itself throws, original exception still propagates."""
+        conn1, _ = _make_mock_conn()
+
+        bad_conn = MagicMock()
+        bad_conn.commit = AsyncMock(side_effect=Exception("DB gone"))
+        bad_cur = AsyncMock()
+        bad_cur.execute = AsyncMock()
+        bad_cur_ctx = MagicMock()
+        bad_cur_ctx.__aenter__ = AsyncMock(return_value=bad_cur)
+        bad_cur_ctx.__aexit__ = AsyncMock(return_value=False)
+        bad_conn.cursor = MagicMock(return_value=bad_cur_ctx)
+
+        @asynccontextmanager
+        async def _bad_conn_ctx():
+            yield bad_conn
+
+        call_iter = [_mock_get_connection(conn1), _bad_conn_ctx()]
+        idx = [-1]
+        def next_conn():
+            idx[0] += 1
+            return call_iter[idx[0]]
+
+        original_exc = RuntimeError("encode failed")
+        with patch(_PATCH_CONN, side_effect=next_conn), \
+             self._make_executor_patch(None, raise_exc=original_exc):
+            with pytest.raises(RuntimeError, match="encode failed"):
+                await wardrobe_service.embed_wardrobe_item(self._ITEM_ID_STR, self._S3_KEY)

--- a/tests/test_wardrobe_service.py
+++ b/tests/test_wardrobe_service.py
@@ -390,7 +390,7 @@ class TestEmbedWardrobeItem:
         # First DB call: SET embedding_status = 'embedding'
         sql1, params1 = cur1.execute.call_args[0]
         assert "embedding_status" in sql1
-        assert "embedding" in sql1
+        assert "'embedding'" in sql1
         conn1.commit.assert_awaited_once()
 
         # Second DB call: SET embedding + done

--- a/tests/test_wardrobe_service.py
+++ b/tests/test_wardrobe_service.py
@@ -450,3 +450,42 @@ class TestEmbedWardrobeItem:
              self._make_executor_patch(None, raise_exc=original_exc):
             with pytest.raises(RuntimeError, match="encode failed"):
                 await wardrobe_service.embed_wardrobe_item(self._ITEM_ID_STR, self._S3_KEY)
+
+
+# ---------------------------------------------------------------------------
+# get_wardrobe_item_status
+# ---------------------------------------------------------------------------
+
+class TestGetWardrobeItemStatus:
+    @pytest.mark.asyncio
+    async def test_found_returns_status_string(self):
+        mock_conn, _ = _make_mock_conn(fetchone_return=("done",))
+
+        with patch(_PATCH_CONN, return_value=_mock_get_connection(mock_conn)):
+            result = await wardrobe_service.get_wardrobe_item_status(
+                _USER_ID, str(_ITEM_ID)
+            )
+
+        assert result == "done"
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_none(self):
+        mock_conn, _ = _make_mock_conn(fetchone_return=None)
+
+        with patch(_PATCH_CONN, return_value=_mock_get_connection(mock_conn)):
+            result = await wardrobe_service.get_wardrobe_item_status(
+                _USER_ID, "nonexistent-id"
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_query_filters_by_both_item_id_and_user_id(self):
+        mock_conn, mock_cur = _make_mock_conn(fetchone_return=None)
+
+        with patch(_PATCH_CONN, return_value=_mock_get_connection(mock_conn)):
+            await wardrobe_service.get_wardrobe_item_status(_USER_ID, str(_ITEM_ID))
+
+        params = mock_cur.execute.call_args[0][1]
+        assert str(_ITEM_ID) in params
+        assert _USER_ID in params


### PR DESCRIPTION
## Summary

- Extracts inline `_embed_wardrobe_image` background task from `main.py` into `wardrobe_service.embed_wardrobe_item` — now testable and reusable
- Adds `embedding_status` column (`pending` → `embedding` → `done`/`failed`) to `wardrobe_items` with DB migration
- Adds `GET /wardrobe/{item_id}/status` endpoint (JSON + HTMX HTML badge partial) with HTMX polling badge in the wardrobe card — polling self-terminates on terminal states
- Fixes `encode_image` fetching from wrong S3 bucket (`WEATHER_BUCKET_NAME` → `config.s3_bucket`)

## Test Plan
- [ ] Run `python scripts/db_migrate.py` on RDS before deploying (uses `ADD COLUMN IF NOT EXISTS`, safe on live table)
- [ ] `make test` — 737 passing, 0 failures
- [ ] Upload a wardrobe item with an image; verify badge shows ⏳ pending then transitions to ✓ ready