### PR TITLE
fix: remove local wardrobe_service import shadowing module-level mock

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -996,7 +996,6 @@ async def get_wardrobe_item_status(
     partial instead of JSON. Polling stops automatically when the badge for
     terminal states (done/failed) omits hx-trigger.
     """
-    from app.services import wardrobe_service
     from app.models.wardrobe import WardrobeItemStatusResponse
     from fastapi.responses import HTMLResponse
 


### PR DESCRIPTION
## Summary
- `get_wardrobe_item_status` had a redundant `from app.services import wardrobe_service` inside the handler body
- This local import shadowed the top-level module-level import, so `patch("app.main.wardrobe_service")` in tests never intercepted the call — the real DB-touching code ran instead, causing 500s
- Removing the one redundant line restores the expected mock behaviour

## Test plan
- [ ] CI passes: `TestWardrobeEmbeddingStatus::test_get_wardrobe_item_status_returns_200`
- [ ] CI passes: `TestWardrobeEmbeddingStatus::test_get_wardrobe_item_status_returns_404_when_not_found`